### PR TITLE
Fixes the default startup command from dockerfile

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,10 +7,10 @@ RUN apk --no-cache add ca-certificates && update-ca-certificates
 # Force python update to install Sass
 RUN apk upgrade && \
   apk add --no-cache git \
-    make gcc g++ python
+  make gcc g++ python
 
 EXPOSE 3000
-CMD ["node", "src/index.js"]
+CMD ["npm", "start"]
 
 # Create the working dir
 RUN mkdir -p /opt/app && mkdir /cache


### PR DESCRIPTION
Closes #87 

Kubernetes appears to be using the default startup command from the dockerfile(which doesn't work), this changes it to use the one we normally use from docker-compose.yml

This is starting the server with webpack, which isn't a very production ready method but this is just the demo UI so its not a big deal.