### PR TITLE
Avoid to pass query string to the callback url

### DIFF
--- a/frontend/src/containers/SignUp.js
+++ b/frontend/src/containers/SignUp.js
@@ -13,6 +13,11 @@ class SignUp extends Component {
   onSubmit(e) {
     e.preventDefault();
     this.setState({ isLoading: true });
+    setTimeout(() => {
+      window.location = '/success';
+      // this.props.history.push(`/success`);
+    }, 1500);
+    return false;
   }
 
   render() {
@@ -27,6 +32,7 @@ class SignUp extends Component {
           fontSize: '12px'
         }
       },
+      callbackUrl: '/success',
       required: true
     });
 
@@ -45,7 +51,7 @@ class SignUp extends Component {
               <h3 className="title"> Create your account </h3>
               <p>{`To create your Account simply fill the short form below`}</p>
               <hr />
-              <form action="/success" onSubmit={e => this.onSubmit(e)}>
+              <form onSubmit={e => this.onSubmit(e)}>
                 <div className="field">
                   <label className="label">First Name</label>
                   <div className="control">

--- a/frontend/src/containers/SignUp.js
+++ b/frontend/src/containers/SignUp.js
@@ -13,10 +13,19 @@ class SignUp extends Component {
   onSubmit(e) {
     e.preventDefault();
     this.setState({ isLoading: true });
+    // This timeout is just for demo purpose, to give the user a visual feedback
+    // when the form is sent. In localhost the transaction happens to fast in the
+    // backend and user is redirected automatically, and cannot see the spinner.
     setTimeout(() => {
+      // TODO: forcing the redirect after the form is processed.
+      // Usually a form in a Client side is pointing to some endpoint to process
+      // data sent by the user. Since we are handling part of that with the
+      // `GiveConsent` component we should allow the developer to point to specific
+      // callback.
       window.location = '/success';
-      // this.props.history.push(`/success`);
-    }, 1500);
+    }, 1000);
+
+    // Prevent to send data to default action. This interaction should be improved.
     return false;
   }
 

--- a/frontend/src/containers/SignUp.js
+++ b/frontend/src/containers/SignUp.js
@@ -13,19 +13,6 @@ class SignUp extends Component {
   onSubmit(e) {
     e.preventDefault();
     this.setState({ isLoading: true });
-    // This timeout is just for demo purpose, to give the user a visual feedback
-    // when the form is sent. In localhost the transaction happens to fast in the
-    // backend and user is redirected automatically, and cannot see the spinner.
-    setTimeout(() => {
-      // TODO: forcing the redirect after the form is processed.
-      // Usually a form in a Client side is pointing to some endpoint to process
-      // data sent by the user. Since we are handling part of that with the
-      // `GiveConsent` component we should allow the developer to point to specific
-      // callback.
-      window.location = '/success';
-    }, 1000);
-
-    // Prevent to send data to default action. This interaction should be improved.
     return false;
   }
 

--- a/frontend/src/elements/components/Consent.js
+++ b/frontend/src/elements/components/Consent.js
@@ -72,6 +72,10 @@ class Consent extends React.PureComponent {
     let data = {};
     let processors = this.state.processors.slice();
 
+    if (processors.length < 1 && !ReactDOM.findDOMNode(this)) {
+      return null;
+    }
+
     // Get Data from parent form
     const form = ReactDOM.findDOMNode(this).parentNode;
 

--- a/frontend/src/elements/components/Consent.js
+++ b/frontend/src/elements/components/Consent.js
@@ -55,14 +55,14 @@ class Consent extends React.PureComponent {
   }
 
   onChange(e) {
-    if (this.props.options.onSubmit) {
+    if (this.props.options.onChange) {
       this.props.options.onChange();
     }
   }
 
   callback(e) {
-    if (this.props.options.onSubmit) {
-      this.props.options.callback();
+    if (this.props.options.callbackFn) {
+      this.props.options.callbackFn();
     }
   }
 
@@ -85,8 +85,8 @@ class Consent extends React.PureComponent {
 
     this.giveConsent(data, processors.filter(p => p.enabled).map(p => p.id))
       .then(() => {
-        if (this.props.callbackUrl) {
-          window.location(this.props.callbackUrl);
+        if (this.props.options.callbackUrl) {
+          window.location(this.props.options.callbackUrl);
         }
       })
       .catch(err => {

--- a/frontend/src/elements/components/Consent.js
+++ b/frontend/src/elements/components/Consent.js
@@ -86,7 +86,7 @@ class Consent extends React.PureComponent {
     this.giveConsent(data, processors.filter(p => p.enabled).map(p => p.id))
       .then(() => {
         if (this.props.options.callbackUrl) {
-          window.location(this.props.options.callbackUrl);
+          window.location.assign(this.props.options.callbackUrl);
         }
       })
       .catch(err => {

--- a/frontend/src/elements/components/Consent.js
+++ b/frontend/src/elements/components/Consent.js
@@ -85,7 +85,9 @@ class Consent extends React.PureComponent {
 
     this.giveConsent(data, processors.filter(p => p.enabled).map(p => p.id))
       .then(() => {
-        e.target.submit(); // Submit parent form callback
+        if (this.props.callbackUrl) {
+          window.location(this.props.callbackUrl);
+        }
       })
       .catch(err => {
         console.log(err);

--- a/frontend/src/elements/components/Consent.js
+++ b/frontend/src/elements/components/Consent.js
@@ -72,10 +72,6 @@ class Consent extends React.PureComponent {
     let data = {};
     let processors = this.state.processors.slice();
 
-    if (processors.length < 1 && !ReactDOM.findDOMNode(this)) {
-      return null;
-    }
-
     // Get Data from parent form
     const form = ReactDOM.findDOMNode(this).parentNode;
 


### PR DESCRIPTION
When redirecting in the `give consent` flow, the current callback URL is `/success` (this could be improved though), and right now the query strings are cleaned up for either GET or POST method.

Closes #58 