### PR TITLE
Add update-endpoint

### DIFF
--- a/cg/src/domains/management/subjects/subjects.service.js
+++ b/cg/src/domains/management/subjects/subjects.service.js
@@ -65,23 +65,6 @@ class SubjectsService {
     };
   }
 
-  async getRequestData(id) {
-    const [requestData] = await this.db('rectification_requests')
-      .select(
-        'key',
-        'personal_data',
-        'status',
-        'encrypted_rectification_payload',
-        'rectification_requests.subject_id'
-      )
-      .select(this.db.raw('rectification_requests.id as rectification_request_id'))
-      .select(this.db.raw('rectification_requests.created_at as rectification_request_created_at'))
-      .join('subjects', 'rectification_requests.subject_id', 'subjects.id')
-      .leftJoin('subject_keys', 'subject_keys.subject_id', 'subjects.id')
-      .where({ 'rectification_requests.id': id });
-    return requestData;
-  }
-
   async listRectificationRequests(requestedPage) {
     const page = requestedPage === undefined ? 1 : parseInt(requestedPage, 10);
 
@@ -147,6 +130,23 @@ class SubjectsService {
         total: totalPages
       }
     };
+  }
+
+  async getRequestData(id) {
+    const [requestData] = await this.db('rectification_requests')
+      .select(
+        'key',
+        'personal_data',
+        'status',
+        'encrypted_rectification_payload',
+        'rectification_requests.subject_id'
+      )
+      .select(this.db.raw('rectification_requests.id as rectification_request_id'))
+      .select(this.db.raw('rectification_requests.created_at as rectification_request_created_at'))
+      .join('subjects', 'rectification_requests.subject_id', 'subjects.id')
+      .leftJoin('subject_keys', 'subject_keys.subject_id', 'subjects.id')
+      .where({ 'rectification_requests.id': id });
+    return requestData;
   }
 
   async updateRectificationRequestStatus(requestId, status) {

--- a/cg/src/domains/management/subjects/subjects.service.js
+++ b/cg/src/domains/management/subjects/subjects.service.js
@@ -20,13 +20,13 @@ class SubjectsService {
       .count('personal_data');
 
     const numberOfsubjects = numberOfsubjectsObject.count;
-    let lastPage = Math.ceil(numberOfsubjects / PAGE_SIZE);
-    if (lastPage === 0) {
+    let totalPages = Math.ceil(numberOfsubjects / PAGE_SIZE);
+    if (totalPages === 0) {
       // Handles the case in which there are no valid subjects, with valid encryption keys and all, in the db
-      lastPage = 1;
+      totalPages = 1;
     }
-    if (requestedPage > lastPage) {
-      throw new ValidationError(`page number too big, maximum page number is ${lastPage}`);
+    if (requestedPage > totalPages) {
+      throw new ValidationError(`page number too big, maximum page number is ${totalPages}`);
     }
     const encryptedSubjectsData = await this.db('subjects')
       .join('subject_keys', 'subjects.id', '=', 'subject_keys.subject_id')
@@ -57,17 +57,15 @@ class SubjectsService {
       .filter(subject => subject !== null);
 
     return {
+      data: decryptedSubjectsData,
       paging: {
         current: requestedPage,
-        total: lastPage
-      },
-      data: decryptedSubjectsData
+        total: totalPages
+      }
     };
   }
 
-  async listRectificationRequests(requestedPage) {
-    const page = requestedPage === undefined ? 1 : parseInt(requestedPage, 10);
-
+  async listRectificationRequests(requestedPage = 1) { 
     const [{ total_items }] = await this.db('rectification_requests')
       .where('status', RECTIFICATION_STATUSES.PENDING)
       .join('subject_keys', 'rectification_requests.subject_id', 'subject_keys.subject_id')
@@ -75,11 +73,9 @@ class SubjectsService {
       .as('total_items');
 
     const totalPages = Math.ceil(total_items / PAGE_SIZE || 1);
-
-    if (page > totalPages) {
+    if (requestedPage > totalPages) {
       throw new ValidationError(`Page number too big, maximum page number is ${totalPages}`);
     }
-
     const requests = await this.db('rectification_requests')
       .select('id')
       .select('request_reason')
@@ -87,20 +83,18 @@ class SubjectsService {
       .where('status', RECTIFICATION_STATUSES.PENDING)
       .join('subject_keys', 'rectification_requests.subject_id', 'subject_keys.subject_id')
       .limit(PAGE_SIZE)
-      .offset(page - 1);
+      .offset((requestedPage - 1 ) * PAGE_SIZE);
 
     return {
       data: requests,
       paging: {
-        current: page,
+        current: requestedPage,
         total: totalPages
       }
     };
   }
 
-  async listProcessedRectificationRequests(requestedPage) {
-    const page = requestedPage === undefined ? 1 : parseInt(requestedPage, 10);
-
+  async listProcessedRectificationRequests(requestedPage = 1) {
     const [{ total_items }] = await this.db('rectification_requests')
       .whereNot('status', RECTIFICATION_STATUSES.PENDING)
       .leftJoin('subject_keys', 'rectification_requests.subject_id', 'subject_keys.subject_id')
@@ -108,11 +102,9 @@ class SubjectsService {
       .as('total_items');
 
     const totalPages = Math.ceil(total_items / PAGE_SIZE || 1);
-
-    if (page > totalPages) {
+    if (requestedPage > totalPages) {
       throw new ValidationError(`Page number too big, maximum page number is ${totalPages}`);
     }
-
     const requests = await this.db('rectification_requests')
       .select('id')
       .select('request_reason')
@@ -121,12 +113,12 @@ class SubjectsService {
       .whereNot('status', RECTIFICATION_STATUSES.PENDING)
       .leftJoin('subject_keys', 'rectification_requests.subject_id', 'subject_keys.subject_id')
       .limit(PAGE_SIZE)
-      .offset(page - 1);
+      .offset((requestedPage - 1) * PAGE_SIZE);
 
     return {
       data: requests,
       paging: {
-        current: page,
+        current: requestedPage,
         total: totalPages
       }
     };

--- a/cg/src/domains/management/subjects/subjects.service.js
+++ b/cg/src/domains/management/subjects/subjects.service.js
@@ -12,23 +12,6 @@ class SubjectsService {
     this.db = database;
   }
 
-  async getRequestData(id) {
-    const [requestData] = await this.db('rectification_requests')
-      .select(
-        'key',
-        'personal_data',
-        'status',
-        'encrypted_rectification_payload',
-        'rectification_requests.subject_id'
-      )
-      .select(this.db.raw('rectification_requests.id as rectification_request_id'))
-      .select(this.db.raw('rectification_requests.created_at as rectification_request_created_at'))
-      .join('subjects', 'rectification_requests.subject_id', 'subjects.id')
-      .leftJoin('subject_keys', 'subject_keys.subject_id', 'subjects.id')
-      .where({ 'rectification_requests.id': id });
-    return requestData;
-  }
-
   async listSubjects(requestedPage = 1) {
     const [numberOfsubjectsObject] = await this.db('subjects')
       .join('subject_keys', 'subjects.id', '=', 'subject_keys.subject_id')
@@ -80,6 +63,23 @@ class SubjectsService {
       },
       data: decryptedSubjectsData
     };
+  }
+
+  async getRequestData(id) {
+    const [requestData] = await this.db('rectification_requests')
+      .select(
+        'key',
+        'personal_data',
+        'status',
+        'encrypted_rectification_payload',
+        'rectification_requests.subject_id'
+      )
+      .select(this.db.raw('rectification_requests.id as rectification_request_id'))
+      .select(this.db.raw('rectification_requests.created_at as rectification_request_created_at'))
+      .join('subjects', 'rectification_requests.subject_id', 'subjects.id')
+      .leftJoin('subject_keys', 'subject_keys.subject_id', 'subjects.id')
+      .where({ 'rectification_requests.id': id });
+    return requestData;
   }
 
   async listRectificationRequests(requestedPage) {

--- a/cg/src/domains/subjects/data-shares.controller.js
+++ b/cg/src/domains/subjects/data-shares.controller.js
@@ -16,12 +16,12 @@ class DataShareController {
 
   async removeDataShare(req, res) {
     await this.service.removeDataShare(req.params.dataShareId);
-    return res.json({ success: true });
+    res.json({ success: true });
   }
 
   async share(req, res) {
     const userData = await this.service.getDataForShare(req.query.token);
-    return res.json(userData);
+    res.json(userData);
   }
 }
 

--- a/cg/src/domains/subjects/subjects.controller.js
+++ b/cg/src/domains/subjects/subjects.controller.js
@@ -12,8 +12,15 @@ class SubjectsController {
       req.body.personalData,
       req.body.processors || []
     );
+    res.send( { success: true } );
+  }
 
-    res.send('OK');
+  async updateConsent(req, res) {
+    await this.subjectsService.updateConsent(
+      req.subject.id,
+      req.body.processors || []
+    );
+    res.send( { success: true } );
   }
 
   async requestDataAccess(req, res) {

--- a/cg/src/domains/subjects/subjects.controller.js
+++ b/cg/src/domains/subjects/subjects.controller.js
@@ -12,7 +12,7 @@ class SubjectsController {
       req.body.personalData,
       req.body.processors || []
     );
-    res.send( { success: true } );
+    res.send({ success: true });
   }
 
   async updateConsent(req, res) {
@@ -20,7 +20,7 @@ class SubjectsController {
       req.subject.id,
       req.body.processors || []
     );
-    res.send( { success: true } );
+    res.send({ success: true });
   }
 
   async requestDataAccess(req, res) {
@@ -30,7 +30,7 @@ class SubjectsController {
 
   async eraseData(req, res) {
     await this.subjectsService.eraseDataAndRevokeConsent(req.subject.id);
-    res.send('OK');
+    res.send({ success: true });
   }
 
   async getPersonalDataStatus(req, res) {

--- a/cg/src/domains/subjects/subjects.routes.js
+++ b/cg/src/domains/subjects/subjects.routes.js
@@ -65,17 +65,17 @@ module.exports = app => {
     asyncHandler(async (req, res) => subjectsController.updateConsent(req, res))
   );
 
-  router.post(
-    '/erase-data',
-    controllerOnly,
-    asyncHandler(async (req, res) => subjectsController.eraseData(req, res))
-  );
-
   router.get(
     '/access-data',
     asyncHandler(async (req, res) => subjectsController.requestDataAccess(req, res))
   );
 
+  router.post(
+    '/erase-data',
+    controllerOnly,
+    asyncHandler(async (req, res) => subjectsController.eraseData(req, res))
+  );
+  
   router.get(
     '/data-status',
     asyncHandler(async (req, res) => subjectsController.getPersonalDataStatus(req, res))

--- a/cg/src/domains/subjects/subjects.routes.js
+++ b/cg/src/domains/subjects/subjects.routes.js
@@ -10,7 +10,11 @@ const {
   shareDataShareValidator
 } = require('./data-shares.validators');
 
-const { rectificationRequestValidator } = require('./subjects.validators');
+const { 
+  giveConsentValidator,
+  updateConsentValidator,
+  rectificationRequestValidator 
+} = require('./subjects.validators');
 
 const router = express.Router();
 
@@ -24,7 +28,7 @@ const ProcessorsController = require('./processors.controller');
 const processorsController = new ProcessorsController();
 
 module.exports = app => {
-  // not using router, because this is a publicly open endpoint (no need to verify JWT)
+  // Not using router, because this is a publicly open endpoint (no need to verify JWT)
   // also needs to be registered before other routes under /subject, so don't reorder
 
   app.use('/subject', router);
@@ -43,14 +47,22 @@ module.exports = app => {
     asyncHandler(async (req, res) => dataShareController.share(req, res))
   );
 
-  // JWT SECURED ENDPOINTS.
+  // JWT SECURED ENDPOINTS
 
   router.use(verifyJWT, requireSubjectId, transformSubjectId);
 
   router.post(
     '/give-consent',
     controllerOnly,
+    giveConsentValidator,
     asyncHandler(async (req, res) => subjectsController.giveConsent(req, res))
+  );
+
+  router.post(
+    '/update-consent',
+    controllerOnly,
+    updateConsentValidator,
+    asyncHandler(async (req, res) => subjectsController.updateConsent(req, res))
   );
 
   router.post(

--- a/cg/src/domains/subjects/subjects.service.js
+++ b/cg/src/domains/subjects/subjects.service.js
@@ -114,29 +114,6 @@ class SubjectsService {
     await this._saveSubjectEncryptionKey(trx, subjectId, encryptionKey);
   }
 
-  async _updateExistingSubject(trx, subjectId, personalData) {
-    const [subjectKey] = await this.db('subject_keys')
-      .transacting(trx)
-      .where('subject_id', subjectId)
-      .select();
-
-    let encryptionKey;
-    if (subjectKey) {
-      encryptionKey = subjectKey.key;
-    } else {
-      encryptionKey = generateClientKey();
-      await this._saveSubjectEncryptionKey(trx, subjectId, encryptionKey);
-    }
-    const encryptedPersonalData = encryptForStorage(JSON.stringify(personalData), encryptionKey);
-    await this.db('subjects')
-      .transacting(trx)
-      .where('id', subjectId)
-      .update({
-        personal_data: encryptedPersonalData,
-        updated_at: this.db.raw('CURRENT_TIMESTAMP')
-      });
-  }
-
   async _setConsentGiven(trx, subjectId, processorId) {
     const [ subjectProcessor ] = await this.db('subject_processors')
       .transacting(trx)

--- a/cg/src/domains/subjects/subjects.service.js
+++ b/cg/src/domains/subjects/subjects.service.js
@@ -11,7 +11,7 @@ const {
   getSubjectDataState,
   recordErasureByProcessor
 } = require('../../utils/blockchain');
-const { ValidationError, NotFound } = require('../../utils/errors');
+const { ValidationError, NotFound, Unauthorized } = require('../../utils/errors');
 const winston = require('winston');
 const { RECTIFICATION_STATUSES } = require('./../../utils/constants');
 const { inControllerMode } = require('./../../utils/helpers');
@@ -27,21 +27,48 @@ class SubjectsService {
     });
   }
 
-  async registerConsentToProcessData(subjectId, personalData, processorIds = []) {
-    let processorIdsWithAddresses;
+  async registerConsentToProcessData(subjectId, personalData, processorsConsented = []) {
+    const [ subjectExists ] = await this.db('subjects')
+      .where('id', subjectId);
+    
+    let processorIdsWithAddresses;  
+    if(subjectExists) throw new Unauthorized('Subject already gave consent, please use the update-consent endpoint');   
     await this.db.transaction(async trx => {
       await this._initializeUserInTransaction(trx, subjectId, personalData);
-      processorIdsWithAddresses = await this._getProcessorIdsWithAddresses(trx, processorIds);
-      if (processorIdsWithAddresses.length !== processorIds.length) {
-        throw new ValidationError('Specified processor does not exist.');
+      processorIdsWithAddresses = await this._getProcessorIdsWithAddresses(trx, processorsConsented);
+      if (processorIdsWithAddresses.length !== processorsConsented.length) {
+        throw new ValidationError('At least one of the processors specified is not valid');
       }
-      if (processorIdsWithAddresses.some(p => !p.address)) {
+      if(processorIdsWithAddresses.some(p => !p.address)) {
         throw new ValidationError(
           `At least one of the processors doesn't have an address assigned`
         );
       }
       await Promise.all(
-        processorIds.map(processorId => this._setConsentGiven(trx, subjectId, processorId))
+        processorsConsented.map(processor => this._setConsentGiven(trx, subjectId, processor))
+      );
+    });
+    await recordConsentGivenTo(subjectId, processorIdsWithAddresses.map(p => p.address));
+  }
+
+  async updateConsent(subjectId, processorsConsented = []){
+    const [ subjectExists ] = await this.db('subjects')
+      .where('id', subjectId);
+  
+    let processorIdsWithAddresses;    
+    if(!subjectExists) throw new NotFound('Subject not found, please use the give-consent endpoint');
+    await this.db.transaction(async trx => {
+      processorIdsWithAddresses = await this._getProcessorIdsWithAddresses(trx, processorsConsented);
+      if (processorIdsWithAddresses.length !== processorsConsented.length) {
+        throw new ValidationError('At least one of the processors specified is not valid');
+      }
+      if(processorIdsWithAddresses.some(p => !p.address)) {
+        throw new ValidationError(
+          `At least one of the processors doesn't have an address assigned`
+        );
+      }
+      await Promise.all(
+        processorsConsented.map(processor => this._setConsentGiven(trx, subjectId, processor))
       );
     });
     await recordConsentGivenTo(subjectId, processorIdsWithAddresses.map(p => p.address));
@@ -64,32 +91,10 @@ class SubjectsService {
 
     if (!subject) {
       await this._createNewSubject(personalData, trx, subjectId);
-    } else {
-      await this._updateExistingSubject(trx, subjectId, personalData);
+    } 
+    else {
+      throw new Unauthorized('Subject already there!!!!!!');
     }
-  }
-
-  async _updateExistingSubject(trx, subjectId, personalData) {
-    const [subjectKey] = await this.db('subject_keys')
-      .transacting(trx)
-      .where('subject_id', subjectId)
-      .select();
-
-    let encryptionKey;
-    if (subjectKey) {
-      encryptionKey = subjectKey.key;
-    } else {
-      encryptionKey = generateClientKey();
-      await this._saveSubjectEncryptionKey(trx, subjectId, encryptionKey);
-    }
-    const encryptedPersonalData = encryptForStorage(JSON.stringify(personalData), encryptionKey);
-    await this.db('subjects')
-      .transacting(trx)
-      .where('id', subjectId)
-      .update({
-        personal_data: encryptedPersonalData,
-        updated_at: this.db.raw('CURRENT_TIMESTAMP')
-      });
   }
 
   async _createNewSubject(personalData, trx, subjectId) {
@@ -106,7 +111,7 @@ class SubjectsService {
   }
 
   async _setConsentGiven(trx, subjectId, processorId) {
-    const [subjectProcessor] = await this.db('subject_processors')
+    const [ subjectProcessor ] = await this.db('subject_processors')
       .transacting(trx)
       .where({ subject_id: subjectId, processor_id: processorId });
 
@@ -190,7 +195,7 @@ class SubjectsService {
     const [subjectKeyData] = await this.db('subject_keys')
       .where({ subject_id: subjectId })
       .select('key');
-
+      
     if (!subjectKeyData || !subjectKeyData.key) throw new NotFound('Subject keys not found');
     const encryptedRectificationPayload = encryptForStorage(
       JSON.stringify(rectificationPayload),

--- a/cg/src/domains/subjects/subjects.service.js
+++ b/cg/src/domains/subjects/subjects.service.js
@@ -37,6 +37,7 @@ class SubjectsService {
     
     let processorIdsWithAddresses;  
     if(subjectExists) throw new Unauthorized('Subject already gave consent, please use the update-consent endpoint');   
+    let processorIdsWithAddresses;
     await this.db.transaction(async trx => {
       await this._initializeUserInTransaction(trx, subjectId, personalData);
       processorIdsWithAddresses = await this._getProcessorIdsWithAddresses(trx, processorsConsented);
@@ -61,6 +62,7 @@ class SubjectsService {
   
     let processorIdsWithAddresses;    
     if(!subjectExists) throw new NotFound('Subject not found, please use the give-consent endpoint');
+    let processorIdsWithAddresses;
     await this.db.transaction(async trx => {
       processorIdsWithAddresses = await this._getProcessorIdsWithAddresses(trx, processorsConsented);
       if (processorIdsWithAddresses.length !== processorsConsented.length) {

--- a/cg/src/domains/subjects/subjects.service.js
+++ b/cg/src/domains/subjects/subjects.service.js
@@ -35,7 +35,7 @@ class SubjectsService {
     const [ subjectExists ] = await this.db('subjects')
       .where('id', subjectId);
      
-    if(subjectExists) throw new Unauthorized('Subject already gave consent, please use the update-consent endpoint');   
+    if(subjectExists) throw new Unauthorized('Subject already gave consent');   
     let processorIdsWithAddresses;
     await this.db.transaction(async trx => {
       await this._initializeUserInTransaction(trx, subjectId, personalData);
@@ -59,7 +59,7 @@ class SubjectsService {
     const [ subjectExists ] = await this.db('subjects')
       .where('id', subjectId);
     
-    if(!subjectExists) throw new NotFound('Subject not found, please use the give-consent endpoint');
+    if(!subjectExists) throw new NotFound('Subject not found');
     let processorIdsWithAddresses;
     await this.db.transaction(async trx => {
       processorIdsWithAddresses = await this._getProcessorIdsWithAddresses(trx, processorsConsented);

--- a/cg/src/domains/subjects/subjects.validators.js
+++ b/cg/src/domains/subjects/subjects.validators.js
@@ -1,5 +1,24 @@
 const { celebrate, Joi } = require('celebrate');
 
+const giveConsentValidator = celebrate({
+  body: Joi.object().keys({
+    personalData: Joi.object()
+      .required(),
+    processors: Joi.array()
+      .items(Joi.number().positive())
+      .required()  
+  })
+});
+
+const updateConsentValidator = celebrate({
+  body: Joi.object().keys({
+    processors: Joi.array()
+      .items(Joi.number().positive())
+      .required()
+      
+  })
+});
+
 const rectificationRequestValidator = celebrate({
   body: Joi.object().keys({
     rectificationPayload: Joi.object(),
@@ -9,6 +28,10 @@ const rectificationRequestValidator = celebrate({
   })
 });
 
+
+
 module.exports = {
+  giveConsentValidator,
+  updateConsentValidator,
   rectificationRequestValidator
 };

--- a/cg/test/management/subjects.api.spec.js
+++ b/cg/test/management/subjects.api.spec.js
@@ -591,7 +591,7 @@ describe('List rectification requests', () => {
   });
 });
 
-describe('Rectification requests archive', () => {
+describe('Tests of listing archived rectification requests', () => {
   it('Should only list the requests with disapproved and approved statuses', async () => {
     const managementToken = await managementJWT.sign({ id: 1 });
     await createSubjectWithRectification();
@@ -603,7 +603,6 @@ describe('Rectification requests archive', () => {
         Authorization: `Bearer ${managementToken}`
       }
     });
-
     const body = await res.json();
     expect(res.status).toEqual(200);
     expect(body.data).toHaveLength(2);
@@ -617,40 +616,43 @@ describe('Rectification requests archive', () => {
         Authorization: `Bearer ${managementToken}`
       }
     });
-
     const body = await res.json();
     expect(res.status).toEqual(200);
     expect(body.data).toHaveLength(0);
     expect(body.paging).toEqual({ current: 1, total: 1 });
   });
 
+  it('Should list archived requests in pages bigger than 1 correctly', async () => {
+    // const managementToken = await managementJWT.sign({ id: 1 });
+    // const res = await fetch('/api/management/subjects/rectification-requests/archive?page=6', {
+    //   method: 'GET',
+    //   headers: {
+    //     Authorization: `Bearer ${managementToken}`
+    //   }
+    // }); 
+  });
+
   it('Should fail if page number is too big', async () => {
     const managementToken = await managementJWT.sign({ id: 1 });
-
     const res = await fetch('/api/management/subjects/rectification-requests/archive?page=6', {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${managementToken}`
       }
     });
-
     const body = await res.json();
-
     expect(res.status).toEqual(400);
     expect(body.error).toEqual('Page number too big, maximum page number is 1');
   });
 
   it('Should still list rectification requests for users without encryption keys', async () => {
     const managementToken = await managementJWT.sign({ id: 1 });
-
     const { subjectId } = await createSubjectWithRectification({
       status: RECTIFICATION_STATUSES.APPROVED
     });
-
     await createSubjectWithRectification({
       status: RECTIFICATION_STATUSES.DISAPPROVED
     });
-
     await db('subject_keys')
       .delete()
       .where({ subject_id: subjectId });
@@ -661,9 +663,7 @@ describe('Rectification requests archive', () => {
         Authorization: `Bearer ${managementToken}`
       }
     });
-
     const body = await res.json();
-
     expect(res.status).toEqual(200);
     expect(body.data).toHaveLength(2);
   });

--- a/cg/test/subjects/__snapshots__/subjects.api.spec.js.snap
+++ b/cg/test/subjects/__snapshots__/subjects.api.spec.js.snap
@@ -1,6 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Tests of initiate rectification Error if error reason and payload are not provided 1`] = `
+exports[`Tests of subjects giving consent Should not allow a new subject to give consent without specifying the consented processors 1`] = `
+Object {
+  "error": "Bad Request",
+  "message": "child \\"processors\\" fails because [\\"processors\\" is required]",
+  "statusCode": 400,
+  "validation": Object {
+    "keys": Array [
+      "processors",
+    ],
+    "source": "body",
+  },
+}
+`;
+
+exports[`Tests of subjects initiating rectifications Error if error reason and payload are not provided 1`] = `
 Object {
   "error": "Bad Request",
   "message": "child \\"requestReason\\" fails because [\\"requestReason\\" is required]",
@@ -14,7 +28,7 @@ Object {
 }
 `;
 
-exports[`Tests of subject giving consent Should not allow a new subject to give consent without specifying the consented processors 1`] = `
+exports[`Tests of subjects updating their consented processors Should not allow a subject to update consent without specifying the processors consented 1`] = `
 Object {
   "error": "Bad Request",
   "message": "child \\"processors\\" fails because [\\"processors\\" is required]",

--- a/cg/test/subjects/__snapshots__/subjects.api.spec.js.snap
+++ b/cg/test/subjects/__snapshots__/subjects.api.spec.js.snap
@@ -1,19 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Initiate Rectification Error if error reason and payload are not provided 1`] = `
-Object {
-  "error": "Bad Request",
-  "message": "child \\"requestReason\\" fails because [\\"requestReason\\" is required]",
-  "statusCode": 400,
-  "validation": Object {
-    "keys": Array [
-      "requestReason",
-    ],
-    "source": "body",
-  },
-}
-`;
-
 exports[`Tests of initiate rectification Error if error reason and payload are not provided 1`] = `
 Object {
   "error": "Bad Request",

--- a/cg/test/subjects/__snapshots__/subjects.api.spec.js.snap
+++ b/cg/test/subjects/__snapshots__/subjects.api.spec.js.snap
@@ -13,3 +13,31 @@ Object {
   },
 }
 `;
+
+exports[`Tests of initiate rectification Error if error reason and payload are not provided 1`] = `
+Object {
+  "error": "Bad Request",
+  "message": "child \\"requestReason\\" fails because [\\"requestReason\\" is required]",
+  "statusCode": 400,
+  "validation": Object {
+    "keys": Array [
+      "requestReason",
+    ],
+    "source": "body",
+  },
+}
+`;
+
+exports[`Tests of subject giving consent Should not allow a new subject to give consent without specifying the consented processors 1`] = `
+Object {
+  "error": "Bad Request",
+  "message": "child \\"processors\\" fails because [\\"processors\\" is required]",
+  "statusCode": 400,
+  "validation": Object {
+    "keys": Array [
+      "processors",
+    ],
+    "source": "body",
+  },
+}
+`;

--- a/cg/test/subjects/subjects.api.spec.js
+++ b/cg/test/subjects/subjects.api.spec.js
@@ -230,7 +230,7 @@ describe('Tests of subjects giving consent', () => {
     expect(res.ok).toBeFalsy();
     expect(res.status).toBe(Unauthorized.StatusCode);
     expect(await res.json()).toEqual({
-      error: 'Subject already gave consent, please use the update-consent endpoint'
+      error: 'Subject already gave consent'
     })
   });
 
@@ -439,7 +439,7 @@ describe('Tests of subjects updating their consented processors', () => {
     expect(res.ok).toBeFalsy();
     expect(res.status).toBe(NotFound.StatusCode);
     expect(await res.json()).toEqual({
-      error: 'Subject not found, please use the give-consent endpoint'
+      error: 'Subject not found'
     });
   });
 


### PR DESCRIPTION
Closes #257 Closes #233 Closes #253 
Add update-consent endpoint, it's validator and some necessary changes in the give-consent endpoint.
Also fixes the pagination issues in the rectification endpoints.
Tested in Postman, and the test suite is updated and working.
It's ready to receive final reviews!