### PR TITLE
Updated GraphCard proptypes to avoid build failing

### DIFF
--- a/admin/src/components/core/cards/dashboard/GraphCard.js
+++ b/admin/src/components/core/cards/dashboard/GraphCard.js
@@ -22,6 +22,13 @@ const Chart = ({ data }) => {
   );
 };
 
+Chart.propTypes = {
+  data: PropTypes.arrayOf({
+    x: PropTypes.string,
+    y: PropTypes.number
+  })
+};
+
 const GraphCard = props => {
   return (
     <Card cols={props.cols} title={props.title} onClick={props.onClick}>
@@ -42,7 +49,8 @@ GraphCard.propTypes = {
     x: PropTypes.string,
     y: PropTypes.number
   }),
-  onClick: PropTypes.func
+  onClick: PropTypes.func,
+  text: PropTypes.string
 };
 
 export default GraphCard;


### PR DESCRIPTION
To prevent builds from failing, I will push this directly to master asap. Probably some rebase will be needed in certain branches.

The next error is the one related to this fix:

```
Failed to compile.
./src/components/core/cards/dashboard/GraphCard.js
  Line 7:   'data' is missing in props validation  react/prop-types
  Line 32:  'text' is missing in props validation  react/prop-types
```