### PR TITLE
Added missing prop type

### DIFF
--- a/admin/src/components/core/cards/dashboard/ItemsCard.js
+++ b/admin/src/components/core/cards/dashboard/ItemsCard.js
@@ -31,7 +31,8 @@ ItemsCard.propTypes = {
       name: PropTypes.string
     })
   ),
-  onClick: PropTypes.func
+  onClick: PropTypes.func,
+  title: PropTypes.string
 };
 
 export default ItemsCard;


### PR DESCRIPTION
Fixes build failing on master. We need to be mindful of compilation warnings in the admin project because on Travis they will be treated as errors. Somehow a failing build got into master.