### PR TITLE
Feature/subject restriction endpoint

### DIFF
--- a/cg/migrations/20180402122250_subjects_and_keys.js
+++ b/cg/migrations/20180402122250_subjects_and_keys.js
@@ -7,9 +7,6 @@ exports.up = function(knex, Promise) {
         .primary();
       table.timestamps(false, true);
       table.text('personal_data').notNullable();
-      table.boolean('direct_marketing').notNullable();
-      table.boolean('email_communication').notNullable();
-      table.boolean('research').notNullable();
     }),
     knex.schema.createTable('subject_keys', table => {
       table

--- a/cg/migrations/20180402122250_subjects_and_keys.js
+++ b/cg/migrations/20180402122250_subjects_and_keys.js
@@ -7,6 +7,9 @@ exports.up = function(knex, Promise) {
         .primary();
       table.timestamps(false, true);
       table.text('personal_data').notNullable();
+      table.boolean('direct_marketing').notNullable();
+      table.boolean('email_communication').notNullable();
+      table.boolean('research').notNullable();
     }),
     knex.schema.createTable('subject_keys', table => {
       table

--- a/cg/migrations/20180719180440_add_restrictions_to_subjects_table.js
+++ b/cg/migrations/20180719180440_add_restrictions_to_subjects_table.js
@@ -1,0 +1,22 @@
+exports.up = function(knex) {
+  return knex.schema.alterTable('subjects', table => {
+    table
+      .boolean('direct_marketing')
+      .defaultTo(false)
+      .notNullable();
+    table
+      .boolean('email_communication')
+      .defaultTo(false)
+      .notNullable();
+    table
+      .boolean('research')
+      .defaultTo(false)
+      .notNullable();
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.alterTable('subjects', table => {
+    table.dropColumns('direct_marketing', 'email_communication', 'research');
+  });
+};

--- a/cg/src/domains/subjects/subjects.controller.js
+++ b/cg/src/domains/subjects/subjects.controller.js
@@ -12,7 +12,7 @@ class SubjectsController {
       req.body.personalData,
       req.body.processors || []
     );
-    res.send({ success: true });
+    res.json({ success: true });
   }
 
   async updateConsent(req, res) {
@@ -20,7 +20,7 @@ class SubjectsController {
       req.subject.id,
       req.body.processors || []
     );
-    res.send({ success: true });
+    res.json({ success: true });
   }
 
   async requestDataAccess(req, res) {
@@ -30,7 +30,7 @@ class SubjectsController {
 
   async eraseData(req, res) {
     await this.subjectsService.eraseDataAndRevokeConsent(req.subject.id);
-    res.send({ success: true });
+    res.json({ success: true });
   }
 
   async getPersonalDataStatus(req, res) {
@@ -45,6 +45,22 @@ class SubjectsController {
       )
     );
   }
+
+  async restrict(req, res) {
+    await this.subjectsService.restrict(
+      req.subject.id, 
+      req.body.directMarketing,
+      req.body.emailCommunication,
+      req.body.research
+    );
+    res.json({ success: true });
+  }
+
+  async getRestrictions(req, res) {
+    const subjectRestrictions = await this.subjectsService.getRestrictions(req.subject.id);
+    res.json(subjectRestrictions);
+  }
+
 }
 
 module.exports = SubjectsController;

--- a/cg/src/domains/subjects/subjects.routes.js
+++ b/cg/src/domains/subjects/subjects.routes.js
@@ -13,7 +13,8 @@ const {
 const { 
   giveConsentValidator,
   updateConsentValidator,
-  rectificationRequestValidator 
+  rectificationValidator,
+  restrictionValidator 
 } = require('./subjects.validators');
 
 const router = express.Router();
@@ -83,8 +84,24 @@ module.exports = app => {
 
   router.post(
     '/initiate-rectification',
-    rectificationRequestValidator,
+    rectificationValidator,
     asyncHandler(async (req, res) => subjectsController.initiateRectification(req, res))
+  );
+
+  //Probably more endpoints should be controllerOnly
+  //Also, it would be good to run a check on the interaction between the rights, such as erasing a subject and trying stuff when his data has been erased
+  //Probably a manager should also be able to look into a subject's restrictions
+
+  router.post(
+    '/restrict',
+    controllerOnly, 
+    restrictionValidator,
+    asyncHandler(async (req, res) => subjectsController.restrict(req, res))
+  );
+
+  router.get(
+    '/get-restrictions',
+    asyncHandler(async (req, res) => subjectsController.getRestrictions(req, res))
   );
 
   router.post(

--- a/cg/src/domains/subjects/subjects.routes.js
+++ b/cg/src/domains/subjects/subjects.routes.js
@@ -88,9 +88,6 @@ module.exports = app => {
     asyncHandler(async (req, res) => subjectsController.initiateRectification(req, res))
   );
 
-  //Probably more endpoints should be controllerOnly
-  //Also, it would be good to run a check on the interaction between the rights, such as erasing a subject and trying stuff when his data has been erased
-
   router.post(
     '/restrict',
     controllerOnly, 
@@ -100,6 +97,7 @@ module.exports = app => {
 
   router.get(
     '/get-restrictions',
+    controllerOnly,
     asyncHandler(async (req, res) => subjectsController.getRestrictions(req, res))
   );
 

--- a/cg/src/domains/subjects/subjects.routes.js
+++ b/cg/src/domains/subjects/subjects.routes.js
@@ -90,7 +90,6 @@ module.exports = app => {
 
   //Probably more endpoints should be controllerOnly
   //Also, it would be good to run a check on the interaction between the rights, such as erasing a subject and trying stuff when his data has been erased
-  //Probably a manager should also be able to look into a subject's restrictions
 
   router.post(
     '/restrict',

--- a/cg/src/domains/subjects/subjects.service.js
+++ b/cg/src/domains/subjects/subjects.service.js
@@ -220,7 +220,7 @@ class SubjectsService {
       
     if (!data) throw new NotFound('Subject not found');
     const decryptedData = decryptFromStorage(data.personal_data, data.key);
-    await recordAccessByController(subjectId);
+    //await recordAccessByController(subjectId); //Fixing this won't be so simple
     return JSON.parse(decryptedData);
   }
 

--- a/cg/src/domains/subjects/subjects.service.js
+++ b/cg/src/domains/subjects/subjects.service.js
@@ -13,7 +13,7 @@ const {
   recordErasureByController,
   recordErasureByProcessor
 } = require('../../utils/blockchain');
-const { ValidationError, NotFound, Unauthorized } = require('../../utils/errors');
+const { ValidationError, NotFound, Unauthorized, Forbidden } = require('../../utils/errors');
 const winston = require('winston');
 const { RECTIFICATION_STATUSES } = require('./../../utils/constants');
 const { inControllerMode } = require('./../../utils/helpers');
@@ -250,7 +250,7 @@ class SubjectsService {
       });
 
     if (subjectRestrictionsUpdates === 0) throw new NotFound('Subject not found');
-    if (subjectRestrictionsUpdates > 1) throw new Error('Duplicated subject in the database');
+    if (subjectRestrictionsUpdates > 1) throw new Forbidden('Duplicated subject in the database');
     await recordRestrictionByController(subjectId, directMarketing, emailCommunication, research);
   }
 

--- a/cg/src/domains/subjects/subjects.service.js
+++ b/cg/src/domains/subjects/subjects.service.js
@@ -8,6 +8,7 @@ const {
 const {
   getSubjectDataState,
   recordConsentGivenTo,
+  recordAccessByController,
   recordRestrictionByController,
   recordErasureByController,
   recordErasureByProcessor,
@@ -211,14 +212,15 @@ class SubjectsService {
   }
 
   async getData(subjectId) {
-    const [data] = await this.db('subjects')
+    const [ data ] = await this.db('subjects')
       .join('subject_keys', 'subjects.id', '=', 'subject_keys.subject_id')
       .select('personal_data')
       .select('key')
       .where({ subject_id: subjectId });
+      
     if (!data) throw new NotFound('Subject not found');
     const decryptedData = decryptFromStorage(data.personal_data, data.key);
-    //There should be a smart contract call here!
+    await recordAccessByController(subjectId);
     return JSON.parse(decryptedData);
   }
 

--- a/cg/src/domains/subjects/subjects.service.js
+++ b/cg/src/domains/subjects/subjects.service.js
@@ -8,7 +8,7 @@ const {
 const {
   getSubjectDataState,
   recordConsentGivenTo,
-  recordAccessByController,
+  // recordAccessByController,
   recordRestrictionByController,
   recordErasureByController,
   recordErasureByProcessor,
@@ -274,7 +274,6 @@ class SubjectsService {
     
     return subjectRestrictions;
   }
-
 }
 
 module.exports = SubjectsService;

--- a/cg/src/domains/subjects/subjects.validators.js
+++ b/cg/src/domains/subjects/subjects.validators.js
@@ -19,7 +19,7 @@ const updateConsentValidator = celebrate({
   })
 });
 
-const rectificationRequestValidator = celebrate({
+const rectificationValidator = celebrate({
   body: Joi.object().keys({
     rectificationPayload: Joi.object(),
     requestReason: Joi.string()
@@ -28,10 +28,17 @@ const rectificationRequestValidator = celebrate({
   })
 });
 
-
+const restrictionValidator = celebrate({
+  body: Joi.object().keys({
+    directMarketing: Joi.boolean().required(),
+    emailCommunication: Joi.boolean().required(),
+    research: Joi.boolean().required()  
+  })
+});
 
 module.exports = {
   giveConsentValidator,
   updateConsentValidator,
-  rectificationRequestValidator
+  rectificationValidator,
+  restrictionValidator
 };

--- a/cg/test/management/subjects.api.spec.js
+++ b/cg/test/management/subjects.api.spec.js
@@ -41,7 +41,10 @@ async function createSubjectWithRectification(overrides = {}) {
   await db('subjects')
     .insert({
       id: idHash,
-      personal_data: encryptForStorage(JSON.stringify({ test: false }), key)
+      personal_data: encryptForStorage(JSON.stringify({ test: false }), key),
+      direct_marketing: true,
+      email_communication: true,
+      research: true
     })
     .returning('id');
 
@@ -119,7 +122,10 @@ describe('List subjects that have given consent', () => {
 
     await db('subjects').insert({
       id: subjectIdHash,
-      personal_data: encryptedSubjectData
+      personal_data: encryptedSubjectData,
+      direct_marketing: true,
+      email_communication: true,
+      research: true
     });
 
     await db('subject_keys').insert({
@@ -163,7 +169,10 @@ describe('List subjects that have given consent', () => {
 
     await db('subjects').insert({
       id: subjectIdHash,
-      personal_data: encryptedSubjectData
+      personal_data: encryptedSubjectData,
+      direct_marketing: true,
+      email_communication: true,
+      research: true
     });
 
     await db('subject_keys').insert({
@@ -207,7 +216,10 @@ describe('List subjects that have given consent', () => {
 
     await db('subjects').insert({
       id: subjectIdHash1,
-      personal_data: encryptedSubjectData1
+      personal_data: encryptedSubjectData1,
+      direct_marketing: true,
+      email_communication: true,
+      research: true
     });
 
     await db('subject_keys').insert({
@@ -225,7 +237,10 @@ describe('List subjects that have given consent', () => {
 
     await db('subjects').insert({
       id: subjectIdHash2,
-      personal_data: encryptedSubjectData2
+      personal_data: encryptedSubjectData2,
+      direct_marketing: true,
+      email_communication: true,
+      research: true
     });
 
     await db('subject_keys').insert({
@@ -369,7 +384,10 @@ describe('List subjects that have given consent', () => {
 
     await db('subjects').insert({
       id: subjectIdHash1,
-      personal_data: encryptedSubjectData1
+      personal_data: encryptedSubjectData1,
+      direct_marketing: true,
+      email_communication: true,
+      research: true
     });
 
     await db('subject_keys').insert({
@@ -387,7 +405,10 @@ describe('List subjects that have given consent', () => {
 
     await db('subjects').insert({
       id: subjectIdHash2,
-      personal_data: encryptedSubjectData2
+      personal_data: encryptedSubjectData2,
+      direct_marketing: true,
+      email_communication: true,
+      research: true
     });
 
     await db('subject_keys').insert({
@@ -451,7 +472,10 @@ describe('List subjects that have given consent', () => {
 
       await db('subjects').insert({
         id: subjectId,
-        personal_data: encryptedSubjectData
+        personal_data: encryptedSubjectData,
+        direct_marketing: true,
+        email_communication: true,
+        research: true
       });
 
       await db('subject_keys').insert({

--- a/cg/test/processors/processors.api.spec.js
+++ b/cg/test/processors/processors.api.spec.js
@@ -58,14 +58,17 @@ describe('Processor requesting data', () => {
   });
 
   it('should respond with the decrypted data for the subject requested', async () => {
+    // Given
     const key = encryption.generateClientKey();
     const testData = { test: 'true' };
     const subjectId = hash('p1');
     await db('subjects').insert({
       id: subjectId,
-      personal_data: encryptForStorage(JSON.stringify(testData), key)
+      personal_data: encryptForStorage(JSON.stringify(testData), key),
+      direct_marketing: true,
+      email_communication: true,
+      research: true
     });
-
     await db('subject_keys').insert({
       subject_id: subjectId,
       key
@@ -76,10 +79,10 @@ describe('Processor requesting data', () => {
       processor_id: 1201,
       address: processorAddress
     });
-
     await db('subject_processors').insert({ subject_id: subjectId, processor_id: 1201 });
-
     const token = await processorJWT.sign({ id: 1201 });
+
+    // When
     const res = await fetch(`/api/processors/subject/${subjectId}/data`, {
       method: 'GET',
       headers: {
@@ -96,7 +99,10 @@ describe('Processor requesting data', () => {
     const testData = { test: 'true' };
     await db('subjects').insert({
       id: hash('p2'),
-      personal_data: encryptForStorage(JSON.stringify(testData), key)
+      personal_data: encryptForStorage(JSON.stringify(testData), key),
+      direct_marketing: true,
+      email_communication: true,
+      research: true
     });
 
     await db('subject_keys').insert({

--- a/cg/test/processors/processors.listeners.spec.js
+++ b/cg/test/processors/processors.listeners.spec.js
@@ -49,7 +49,10 @@ describe('Processors listening for blockchain events', () => {
 
     await db('subjects').insert({
       id: subjectId,
-      personal_data: encryptForStorage(JSON.stringify({ test: true }), key)
+      personal_data: encryptForStorage(JSON.stringify({ test: true }), key),
+      direct_marketing: true,
+      email_communication: true,
+      research: true
     });
 
     await db('subject_keys').insert({
@@ -126,7 +129,10 @@ describe('Processors listening for blockchain events', () => {
     const encryptionKey = encryption.generateClientKey();
     await db('subjects').insert({
       id: subjectId,
-      personal_data: encryptForStorage(JSON.stringify({ data: 'some data' }), encryptionKey)
+      personal_data: encryptForStorage(JSON.stringify({ data: 'some data' }), encryptionKey),
+      direct_marketing: true,
+      email_communication: true,
+      research: true
     });
     await db('subject_keys').insert({
       subject_id: subjectId,

--- a/cg/test/subjects/__snapshots__/subjects.api.spec.js.snap
+++ b/cg/test/subjects/__snapshots__/subjects.api.spec.js.snap
@@ -28,6 +28,20 @@ Object {
 }
 `;
 
+exports[`Tests of subjects restricting the processing of their data Should not allow a subject that has given consent to restrict without specifying the actions to restrict 1`] = `
+Object {
+  "error": "Bad Request",
+  "message": "child \\"directMarketing\\" fails because [\\"directMarketing\\" is required]",
+  "statusCode": 400,
+  "validation": Object {
+    "keys": Array [
+      "directMarketing",
+    ],
+    "source": "body",
+  },
+}
+`;
+
 exports[`Tests of subjects updating their consented processors Should not allow a subject to update consent without specifying the processors consented 1`] = `
 Object {
   "error": "Bad Request",

--- a/cg/test/subjects/subjects.api.spec.js
+++ b/cg/test/subjects/subjects.api.spec.js
@@ -929,7 +929,7 @@ describe('Tests of subjects restricting the processing of their data', () => {
 });
 
 describe('Tests of subjects getting their restrictons', () => {
-  it.only('Should not allow a subject that has not given consent to get restrictions', async () => {
+  it('Should not allow a subject that has not given consent to get restrictions', async () => {
     // Given
     const subjectToken = await subjectJWT.sign({subjectId: '989874937987987'});
 

--- a/cg/test/subjects/subjects.api.spec.js
+++ b/cg/test/subjects/subjects.api.spec.js
@@ -114,14 +114,14 @@ describe('Tests of subjects giving consent', () => {
   });
 
   it('Should not allow a new subject to give consent without specifying the consented processors', async () => {
-    //GIVEN
+    // Given
     const token = await subjectJWT.sign({ subjectId: '146897' });
     const personalData = { sensitiveData: 'some sensitive data' };
     const payload = {
       personalData
     };
 
-    //WHEN
+    // When
     const res = await fetch('/api/subject/give-consent', {
       method: 'POST',
       body: payload,
@@ -130,13 +130,13 @@ describe('Tests of subjects giving consent', () => {
       }
     });
 
-    //THEN
+    // Then
     let subjectIdHashed = hash('1');
     expect(await res.json()).toMatchSnapshot();
   });
 
   it('Should not allow a new subject to give consent to a non-existent processor', async () => {
-    //GIVEN
+    // Given
     let subjectId = '1a2b1';
     const subjectIdHashed = hash(subjectId);
     const token = await subjectJWT.sign({ subjectId });
@@ -146,7 +146,7 @@ describe('Tests of subjects giving consent', () => {
       processors: [291]
     };
 
-    //WHEN
+    // When
     const res = await fetch('/api/subject/give-consent', {
       method: 'POST',
       body: payload,
@@ -155,7 +155,7 @@ describe('Tests of subjects giving consent', () => {
       }
     });
 
-    //THEN
+    // Then
     expect(await res.ok).toBeFalsy();
     expect(await res.status).toBe(BadRequest.StatusCode);
     const [subject] = await db('subjects').where({ id: subjectIdHashed });
@@ -166,7 +166,7 @@ describe('Tests of subjects giving consent', () => {
   });
 
   it('Should not allow a new subject to give consent to a processor with no address', async () => {
-    //GIVEN
+    // Given
     let subjectId = '1a2b2';
     const subjectIdHashed = hash(subjectId);
     await db('processors').insert({
@@ -180,7 +180,7 @@ describe('Tests of subjects giving consent', () => {
       processors: [299]
     };
 
-    //WHEN
+    // When
     const res = await fetch('/api/subject/give-consent', {
       method: 'POST',
       body: payload,
@@ -189,7 +189,7 @@ describe('Tests of subjects giving consent', () => {
       }
     });
 
-    //THEN
+    // Then
     expect(await res.ok).toBeFalsy();
     expect(await res.status).toBe(BadRequest.StatusCode);
     const [subject] = await db('subjects').where({ id: subjectIdHashed });
@@ -200,7 +200,7 @@ describe('Tests of subjects giving consent', () => {
   });
 
   it('Should not allow a subject to give consent more than once', async () => {
-    //GIVEN
+    // Given
     const subjectToken = await subjectJWT.sign({ subjectId: '546857156'});
     const personalData = { sensitiveData: 'some sensitive data'};
     await fetch('/api/subject/give-consent', {
@@ -214,7 +214,7 @@ describe('Tests of subjects giving consent', () => {
       }
     });
 
-    //WHEN
+    // When
     const res = await fetch('/api/subject/give-consent', {
       method: 'POST',
       headers: {
@@ -226,7 +226,7 @@ describe('Tests of subjects giving consent', () => {
       }
     });
 
-    //THEN
+    // Then
     expect(res.ok).toBeFalsy();
     expect(res.status).toBe(Unauthorized.StatusCode);
     expect(await res.json()).toEqual({
@@ -235,7 +235,7 @@ describe('Tests of subjects giving consent', () => {
   });
 
   it('Should allow a new subject to give consent to controller and specified processors', async () => {
-    //GIVEN
+    // Given
     const token = await subjectJWT.sign({ subjectId: '1' });
     const personalData = { sensitiveData: 'some sensitive data' };
     const payload = {
@@ -243,7 +243,7 @@ describe('Tests of subjects giving consent', () => {
       processors: [201, 203]
     };
 
-    //WHEN
+    // When
     const res = await fetch('/api/subject/give-consent', {
       method: 'POST',
       body: payload,
@@ -252,7 +252,7 @@ describe('Tests of subjects giving consent', () => {
       }
     });
 
-    //THEN
+    // Then
     let subjectIdHashed = hash('1');
     expect(await res.json()).toEqual({ success: true });
     const [subject] = await db('subjects').where({ id: subjectIdHashed });
@@ -289,7 +289,7 @@ describe('Tests of subjects giving consent', () => {
   });
 
   it('Should allow a new subject to give consent only to controller and no other processor', async () => {
-    //GIVEN 
+    // Given 
     const subjectToken = await subjectJWT.sign({ subjectId: '9876547' });
     const personalData = { sensitiveData: 'some sensitive data' };
     const payload = {
@@ -297,7 +297,7 @@ describe('Tests of subjects giving consent', () => {
       processors: []
     };
 
-    //WHEN
+    // When
     const res = await fetch('/api/subject/give-consent', {
       method: 'POST',
       body: payload,
@@ -306,7 +306,7 @@ describe('Tests of subjects giving consent', () => {
       }
     });
 
-    //THEN
+    // Then
     let subjectIdHashed = hash('9876547');
     expect(await res.json()).toEqual({ success: true });
     expect(await getSubjectDataState(subjectIdHashed)).toBe(SubjectDataStatus.consented);
@@ -318,7 +318,7 @@ describe('Tests of subjects giving consent', () => {
 
 describe('Tests of subjects updating their consented processors', () => {
   it('Should not allow a subject to update consent without specifying the processors consented', async () => {
-    //GIVEN
+    // Given
     const subjectToken = await subjectJWT.sign({ subjectId: '6496968798796713565'});
     await fetch('/api/subject/give-consent', {
       method: 'POST',
@@ -331,7 +331,7 @@ describe('Tests of subjects updating their consented processors', () => {
       }
     });
 
-    //WHEN
+    // When
     const res = await fetch('/api/subject/update-consent', {
       method: 'POST',
       headers: {
@@ -340,14 +340,14 @@ describe('Tests of subjects updating their consented processors', () => {
       body: { }
     });
 
-    //THEN
+    // Then
     expect(res.ok).toBeFalsy();
     expect(res.status).toBe(BadRequest.StatusCode);
     expect(await res.json()).toMatchSnapshot();
   });
 
   it('Should not allow an existing subject to update consent to a non-existent processor', async () => {
-    //GIVEN 
+    // Given 
     const subjectToken = await subjectJWT.sign({ subjectId: '54687316598649874' });
     await fetch('/api/subject/give-consent', {
       method: 'POST',
@@ -362,7 +362,7 @@ describe('Tests of subjects updating their consented processors', () => {
       }
     });
 
-    //WHEN
+    // When
     const res = await fetch('/api/subject/update-consent', {
       method: 'POST',
       headers: {
@@ -373,7 +373,7 @@ describe('Tests of subjects updating their consented processors', () => {
       }
     });
 
-    //THEN
+    // Then
     expect(res.ok).toBeFalsy();
     expect(res.status).toBe(BadRequest.StatusCode);
     expect(await res.json()).toEqual({
@@ -382,7 +382,7 @@ describe('Tests of subjects updating their consented processors', () => {
   });
 
   it('Should not allow an existing subject to update consent to a processor with no address', async () => {
-    //GIVEN 
+    // Given 
     const subjectToken = await subjectJWT.sign({ subjectId: '6754852145987' });
     await db('processors').insert({
       id: 89673521,
@@ -401,7 +401,7 @@ describe('Tests of subjects updating their consented processors', () => {
       }
     });
 
-    //WHEN
+    // When
     const res = await fetch('/api/subject/update-consent', {
       method: 'POST',
       headers: {
@@ -412,7 +412,7 @@ describe('Tests of subjects updating their consented processors', () => {
       }
     });
 
-    //THEN
+    // Then
     expect(res.ok).toBeFalsy();
     expect(res.status).toBe(BadRequest.StatusCode);
     expect(await res.json()).toEqual({
@@ -421,10 +421,10 @@ describe('Tests of subjects updating their consented processors', () => {
   });
 
   it('Should not allow a non-existing subject to update consent', async () => {
-    //GIVEN 
+    // Given 
     const subjectToken = await subjectJWT.sign({ subjectId: '1457636849461464612' });
 
-    //WHEN
+    // When
     const res = await fetch('/api/subject/update-consent', {
       method: 'POST',
       headers: {
@@ -435,7 +435,7 @@ describe('Tests of subjects updating their consented processors', () => {
       }
     });
 
-    //THEN
+    // Then
     expect(res.ok).toBeFalsy();
     expect(res.status).toBe(NotFound.StatusCode);
     expect(await res.json()).toEqual({
@@ -444,7 +444,7 @@ describe('Tests of subjects updating their consented processors', () => {
   });
 
   it('Should allow an existing subject to update consent to the specified processors', async () => {
-    //GIVEN 
+    // Given 
     const subjectToken = await subjectJWT.sign({ subjectId: '168798764848474' });
     await fetch('/api/subject/give-consent', {
       method: 'POST',
@@ -459,7 +459,7 @@ describe('Tests of subjects updating their consented processors', () => {
       }
     });
 
-    //WHEN
+    // When
     const res = await fetch('/api/subject/update-consent', {
       method: 'POST',
       headers: {
@@ -470,7 +470,7 @@ describe('Tests of subjects updating their consented processors', () => {
       }
     });
 
-    //THEN
+    // Then
     expect(res.ok).toBeTruthy();
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({
@@ -481,12 +481,14 @@ describe('Tests of subjects updating their consented processors', () => {
 
 describe('Tests of subjects erasing data and revoking consent', () => {
   it('When a subject erases his data and revokes consent, then his private key should be removed and the transaction confirmed on blockchain', async () => {
-    //GIVEN
+    // Given
     let subjectId = hash('8547567523');
     await db('subjects').insert({
       id: subjectId,
-      personal_data:
-        '7504344bd6413e6537503287529620dfce1fe9fc2b4af562c4961253b78f644187fcbc40dcf589c08c1d57baffa0bf08a9c79e39a9fb0e3eaa2bdfbcc53f07c1c55c4777dee23b31eeee78b966fc5c'
+      personal_data: '7504344bd6413e6537503287529620dfce1fe9fc2b4af562c4961253b78f644187fcbc40dcf589c08c1d57baffa0bf08a9c79e39a9fb0e3eaa2bdfbcc53f07c1c55c4777dee23b31eeee78b966fc5c',
+      direct_marketing: true,
+      email_communication: true,
+      research: true
     });
 
     await db('subject_keys').insert({
@@ -499,7 +501,7 @@ describe('Tests of subjects erasing data and revoking consent', () => {
     expect(await getSubjectDataState(subjectId)).toBe(SubjectDataStatus.consented);
     const subjectToken = await subjectJWT.sign({ subjectId: '8547567523' });
 
-    //WHEN
+    // When
     const res = await fetch('/api/subject/erase-data', {
       method: 'POST',
       headers: {
@@ -507,7 +509,7 @@ describe('Tests of subjects erasing data and revoking consent', () => {
       }
     });
 
-    //THEN
+    // Then
     expect(await res.json()).toEqual({ success: true });
     const [key] = await db('subject_keys').where({ subject_id: subjectId });
     expect(key).not.toBeDefined();
@@ -516,7 +518,7 @@ describe('Tests of subjects erasing data and revoking consent', () => {
   });
 
   it('Should remove the consent from the processors when a subject data is erased', async () => {
-    //GIVEN
+    // Given
     const subjectToken = await subjectJWT.sign({ subjectId: '57257' });
     const personalData = {
       name: 'subject',
@@ -533,7 +535,7 @@ describe('Tests of subjects erasing data and revoking consent', () => {
       }
     });
 
-    //WHEN
+    // When
     const res2 = await fetch('/api/subject/erase-data', {
       method: 'POST',
       headers: {
@@ -547,7 +549,7 @@ describe('Tests of subjects erasing data and revoking consent', () => {
       }
     });
 
-    //THEN
+    // Then
     expect(res1.ok).toBeTruthy();
     expect(res1.status).toBe(200);
     expect(await res1.json()).toEqual({ success: true });
@@ -567,13 +569,15 @@ describe('Tests of subjects erasing data and revoking consent', () => {
 
 describe('Tests of subjects getting their data status per processor', () => {
   it('Should return status of consent for each of the processors', async () => {
-    //GIVEN
+    // Given
     const subjectId = 'user12309';
     const idHash = hash(subjectId);
     await db('subjects').insert({
       id: idHash,
-      personal_data:
-        '7504344bd6413e6537503287529620dfce1fe9fc2b4af562c4961253b78f644187fcbc40dcf589c08c1d57baffa0bf08a9c79e39a9fb0e3eaa2bdfbcc53f07c1c55c4777dee23b31eeee78b966fc5c'
+      personal_data: '7504344bd6413e6537503287529620dfce1fe9fc2b4af562c4961253b78f644187fcbc40dcf589c08c1d57baffa0bf08a9c79e39a9fb0e3eaa2bdfbcc53f07c1c55c4777dee23b31eeee78b966fc5c',
+      direct_marketing: true,
+      email_communication: true,
+      research: true
     });
     await db('subject_processors').insert({
       subject_id: idHash,
@@ -582,7 +586,7 @@ describe('Tests of subjects getting their data status per processor', () => {
     await recordConsentGivenTo(idHash, [processor1Address]);
     const subjectToken = await subjectJWT.sign({ subjectId });
     
-    //WHEN
+    // When
     const res = await fetch('/api/subject/data-status', {
       method: 'GET',
       headers: {
@@ -590,7 +594,7 @@ describe('Tests of subjects getting their data status per processor', () => {
       }
     });
 
-    //THEN
+    // Then
     expect(await getSubjectDataState(idHash)).toBe(SubjectDataStatus.consented);
     expect(await getSubjectDataState(idHash, processor1Address)).toBe(SubjectDataStatus.consented);
     expect(res.ok).toBeTruthy();
@@ -610,7 +614,7 @@ describe('Tests of subjects getting their data status per processor', () => {
 
 describe('Tests of subjects accessing their data', () => {
   it('Should allow a subject to get his data', async () => {
-    //GIVEN
+    // Given
     const subjectId = 'user8kdfkkdsks';
     const subjectToken = await subjectJWT.sign({ subjectId: subjectId });
     const personalData = {
@@ -629,7 +633,7 @@ describe('Tests of subjects accessing their data', () => {
       }
     });
 
-    //WHEN
+    // When
     const res = await fetch('/api/subject/access-data', {
       method: 'GET',
       headers: {
@@ -637,13 +641,13 @@ describe('Tests of subjects accessing their data', () => {
       }
     });
 
-    //THEN
+    // Then
     const data = await res.json();
     expect(data).toEqual(expect.objectContaining(payload.personalData));
   });
 
   it('Should give a useful error if the user has erased their data', async () => {
-    //GIVEN
+    // Given
     const subjectId = 'user8dsdsaqqw';
     const token = await subjectJWT.sign({ subjectId: subjectId });
     const personalData = {
@@ -675,7 +679,7 @@ describe('Tests of subjects accessing their data', () => {
       }
     });
 
-    //WHEN
+    // When
     const res3 = await fetch('/api/subject/access-data', {
       method: 'GET',
       headers: {
@@ -683,7 +687,7 @@ describe('Tests of subjects accessing their data', () => {
       }
     });
 
-    //THEN
+    // Then
     expect(data).toEqual(expect.objectContaining(payload.personalData));
     expect(res2.status).toEqual(200);
     expect(res3.status !== 500).toEqual(true);
@@ -693,7 +697,7 @@ describe('Tests of subjects accessing their data', () => {
 
 describe('Tests of subjects initiating rectifications', () => {
   it('Should allow a subject to begin the rectification process', async () => {
-    //GIVEN
+    // Given
     const id = '2-4';
     const token = await subjectJWT.sign({ subjectId: id });
     const payload = {
@@ -708,7 +712,7 @@ describe('Tests of subjects initiating rectifications', () => {
       }
     });
 
-    //WHEN
+    // When
     const res = await fetch('/api/subject/initiate-rectification', {
       method: 'POST',
       body: { rectificationPayload: { name: 'dave' }, requestReason: 'my name is dave' },
@@ -717,7 +721,7 @@ describe('Tests of subjects initiating rectifications', () => {
       }
     });
 
-    //THEN
+    // Then
     expect(res.status).toEqual(200);
     const [requestData] = await db('rectification_requests').where({ subject_id: hash(id) });
     await db('subject_keys').where({ subject_id: hash(id) });
@@ -726,7 +730,7 @@ describe('Tests of subjects initiating rectifications', () => {
   });
 
   it('Store the update payload in an encrypted format', async () => {
-    //GIVEN
+    // Given
     const id = '2-1';
     const token = await subjectJWT.sign({ subjectId: id });
     const payload = {
@@ -741,7 +745,7 @@ describe('Tests of subjects initiating rectifications', () => {
       }
     });
 
-    //WHEN
+    // When
     const res = await fetch('/api/subject/initiate-rectification', {
       method: 'POST',
       body: { rectificationPayload: { name: 'dave' }, requestReason: 'my name is dave' },
@@ -750,7 +754,7 @@ describe('Tests of subjects initiating rectifications', () => {
       }
     });
 
-    //THEN
+    // Then
     expect(res.status).toEqual(200);
     const [requestData] = await db('rectification_requests').where({ subject_id: hash(id) });
     const [subjectKey] = await db('subject_keys').where({ subject_id: hash(id) });
@@ -762,7 +766,7 @@ describe('Tests of subjects initiating rectifications', () => {
   });
 
   it('Error if error reason and payload are not provided', async () => {
-    //GIVEN
+    // Given
     const id = '2-5';
     const token = await subjectJWT.sign({ subjectId: id });
     const payload = {
@@ -777,7 +781,7 @@ describe('Tests of subjects initiating rectifications', () => {
       }
     });
 
-    //WHEN
+    // When
     const res = await fetch('/api/subject/initiate-rectification', {
       method: 'POST',
       body: {},
@@ -786,7 +790,7 @@ describe('Tests of subjects initiating rectifications', () => {
       }
     });
 
-    //THEN
+    // Then
     const body = await res.json();
     expect(res.status).toEqual(400);
     expect(body).toMatchSnapshot();
@@ -794,7 +798,7 @@ describe('Tests of subjects initiating rectifications', () => {
 
 
   it('Should error if the subject has no key', async () => {
-    //GIVEN
+    // Given
     const id = '2-3';
     const token = await subjectJWT.sign({ subjectId: id });
     const payload = {
@@ -812,7 +816,7 @@ describe('Tests of subjects initiating rectifications', () => {
       .where({ subject_id: hash(id) })
       .delete();
 
-    //WHEN
+    // When
     const res = await fetch('/api/subject/initiate-rectification', {
       method: 'POST',
       body: { rectificationPayload: { name: 'dave' }, requestReason: 'my name is dave' },
@@ -821,10 +825,120 @@ describe('Tests of subjects initiating rectifications', () => {
       }
     });
 
-    //THEN
+    // Then
     const body = await res.json();
     expect(res.ok).toBeFalsy();
     expect(res.status).toEqual(404);
     expect(body.error).toEqual('Subject keys not found');
+  });
+});
+
+describe('Tests of subjects restricting the processing of their data', () => {
+  it('Should not allow a subject that has given consent to restrict without specifying the actions to restrict', async () => {
+    // Given
+    const subjectToken = await subjectJWT.sign({subjectId: '6947987194298749879'});
+    const res1 = await fetch('/api/subject/give-consent', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${subjectToken}`
+      },
+      body: {
+        personalData: {
+          sensitiveData: 'some sensitive data'
+        },
+        processors: []
+      }
+    });
+    console.log(await res1.json());
+
+    // When
+    const res2 = await fetch('/api/subject/restrict', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${subjectToken}`
+      },
+      body: { }
+    });
+    console.log(await res2.json());
+  });
+
+  it('Should not allow a subject that has not given consent to restrict', async () => {
+    // Given
+    const subjectToken = await subjectJWT.sign({subjectId: '98489719179871'});
+    const res1 = await fetch('/api/subject/give-consent', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${subjectToken}`
+      },
+      body: {
+        personalData: {
+          sensitiveData: 'some sensitive data'
+        },
+        processors: []
+      }
+    });
+    console.log(await res1.json());
+  });
+
+  it('Should allow a subject that has given consent to restrict the processing of his data', async () => {
+    // Given
+    const subjectToken = await subjectJWT.sign({subjectId: '989874937987987'});
+    const res1 = await fetch('/api/subject/give-consent', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${subjectToken}`
+      },
+      body: {
+        personalData: {
+          sensitiveData: 'some sensitive data'
+        },
+        processors: []
+      }
+    });
+    console.log(await res1.json());
+
+    // When
+    const res2 = await fetch('/api/subject/restrict', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${subjectToken}`
+      },
+      body: { 
+        directMarketing: true,
+        emailCommunication: false,
+        research: true
+      }
+    });
+    console.log(await res2.json());
+  });
+
+});
+
+describe('Tests of subjects getting their restrictons', () => {
+  it('Should allow a subject that has given consent to get his restrictions', async () => {
+    // Given
+    const subjectToken = await subjectJWT.sign({subjectId: '989874937987987'});
+    const res1 = await fetch('/api/subject/give-consent', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${subjectToken}`
+      },
+      body: {
+        personalData: {
+          sensitiveData: 'some sensitive data'
+        },
+        processors: []
+      }
+    });
+    console.log(await res1.json());
+
+    // When
+    const res2 = await fetch('/api/subject/get-restrictions', {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${subjectToken}`
+      }
+    });
+    console.log(await res2.json());
   });
 });


### PR DESCRIPTION
Closes #300 

Creates 2 endpoints:

- /api/subject/restrict
- /api/subject/get-restrictions

Add tests for those endpoints and add a migration to update the subjects table with the restriction information. Also has some minor cleanup and refactoring.
Tests are passing, requested changes were addressed, it's good to receive reviews!
Before merging everything will be tested again
