### PR TITLE
Fix/processors domain reaching into subjects domain

### DIFF
--- a/cg/src/domains/processors/processors.controller.js
+++ b/cg/src/domains/processors/processors.controller.js
@@ -10,7 +10,7 @@ class ProcessorsController {
 
   async getSubjectData(req, res) {
     const subjectId = req.params.subjectId;
-    const subjectData = await this.processorsService.getData(subjectId);
+    const subjectData = await this.processorsService.getSubjectData(subjectId);
     return res.json(subjectData);
   }
 

--- a/cg/src/domains/processors/processors.controller.js
+++ b/cg/src/domains/processors/processors.controller.js
@@ -1,16 +1,16 @@
-const ProcessorsService = require('./processors.service');
+const SubjectsService = require('./processors.service');
 const ContractService = require('./contract.service');
 const { NotFound } = require('../../utils/errors');
 
 class ProcessorsController {
-  constructor(processorsService = null, contractService = null) {
-    this.processorsService = processorsService || new ProcessorsService();
+  constructor(subjectsService = null, contractService = null) {
+    this.subjectsService = subjectsService || new SubjectsService();
     this.contractService = contractService || new ContractService();
   }
 
   async getSubjectData(req, res) {
     const subjectId = req.params.subjectId;
-    const subjectData = await this.processorsService.getSubjectData(subjectId);
+    const subjectData = await this.subjectsService.getSubjectData(subjectId);
     return res.json(subjectData);
   }
 

--- a/cg/src/domains/processors/processors.controller.js
+++ b/cg/src/domains/processors/processors.controller.js
@@ -1,18 +1,16 @@
-const SubjectsService = require('./../subjects/subjects.service');
-const ContractService = require('./../management/contract/contract.service');
+const ProcessorsService = require('./processors.service');
+const ContractService = require('./contract.service');
 const { NotFound } = require('../../utils/errors');
 
-// TODO: maybe we don't want to reach into the subjects / management domain?
-
 class ProcessorsController {
-  constructor(subjectsService = null, contractService = null) {
-    this.subjectsService = subjectsService || new SubjectsService();
+  constructor(processorsService = null, contractService = null) {
+    this.processorsService = processorsService || new ProcessorsService();
     this.contractService = contractService || new ContractService();
   }
 
-  async getData(req, res) {
+  async getSubjectData(req, res) {
     const subjectId = req.params.subjectId;
-    const subjectData = await this.subjectsService.getData(subjectId);
+    const subjectData = await this.processorsService.getData(subjectId);
     return res.json(subjectData);
   }
 

--- a/cg/src/domains/processors/processors.controller.js
+++ b/cg/src/domains/processors/processors.controller.js
@@ -1,4 +1,4 @@
-const SubjectsService = require('./processors.service');
+const SubjectsService = require('./subjects.service');
 const ContractService = require('./contract.service');
 const { NotFound } = require('../../utils/errors');
 

--- a/cg/src/domains/processors/processors.listeners.js
+++ b/cg/src/domains/processors/processors.listeners.js
@@ -6,10 +6,10 @@ const {
 const { getDataForSubject } = require('./processors.requests');
 const { blockUntilContractReady } = require('./processors.helpers');
 const { inControllerMode } = require('../../utils/helpers');
-const SubjectsService = require('./../subjects/subjects.service');
+const ProcessorsService = require('./processors.service');
 const winston = require('winston');
 
-const subjectsService = new SubjectsService();
+const processorsService = new ProcessorsService();
 
 const startConsentEventListener = () => {
   return listenerForConsentEvent(async subjectId => {
@@ -17,7 +17,7 @@ const startConsentEventListener = () => {
     const response = await getDataForSubject(subjectId).catch(err => {
       return Promise.reject(err);
     });
-    await subjectsService.initializeUser(subjectId, await response.json());
+    await processorsService.initializeUser(subjectId, await response.json());
   });
 };
 
@@ -27,14 +27,14 @@ const startRectificationEventListener = () => {
     const response = await getDataForSubject(subjectId).catch(err => {
       return Promise.reject(err);
     });
-    await subjectsService.initializeUser(subjectId, await response.json());
+    await processorsService.initializeUser(subjectId, await response.json());
   });
 };
 
 const startErasureEventListener = () => {
   return listenerForErasureEvent(async subjectId => {
     winston.info(`Erasure event received for subject ${subjectId}`);
-    await subjectsService.eraseDataAndRevokeConsent(subjectId);
+    await processorsService.eraseDataAndRevokeConsent(subjectId);
   });
 };
 

--- a/cg/src/domains/processors/processors.listeners.js
+++ b/cg/src/domains/processors/processors.listeners.js
@@ -6,10 +6,10 @@ const {
 const { getDataForSubject } = require('./processors.requests');
 const { blockUntilContractReady } = require('./processors.helpers');
 const { inControllerMode } = require('../../utils/helpers');
-const ProcessorsService = require('./processors.service');
+const SubjectsService = require('./subjects.service');
 const winston = require('winston');
 
-const processorsService = new ProcessorsService();
+const subjectsService = new SubjectsService();
 
 const startConsentEventListener = () => {
   return listenerForConsentEvent(async subjectId => {
@@ -17,7 +17,7 @@ const startConsentEventListener = () => {
     const response = await getDataForSubject(subjectId).catch(err => {
       return Promise.reject(err);
     });
-    await processorsService.initializeUser(subjectId, await response.json());
+    await subjectsService.initializeUser(subjectId, await response.json());
   });
 };
 
@@ -27,14 +27,14 @@ const startRectificationEventListener = () => {
     const response = await getDataForSubject(subjectId).catch(err => {
       return Promise.reject(err);
     });
-    await processorsService.initializeUser(subjectId, await response.json());
+    await subjectsService.initializeUser(subjectId, await response.json());
   });
 };
 
 const startErasureEventListener = () => {
   return listenerForErasureEvent(async subjectId => {
     winston.info(`Erasure event received for subject ${subjectId}`);
-    await processorsService.eraseDataAndRevokeConsent(subjectId);
+    await subjectsService.eraseDataAndRevokeConsent(subjectId);
   });
 };
 

--- a/cg/src/domains/processors/processors.routes.js
+++ b/cg/src/domains/processors/processors.routes.js
@@ -4,8 +4,8 @@ const { controllerOnly } = require('./../../utils/middleware');
 const asyncHandler = require('express-async-handler');
 const router = express.Router();
 
-const processorController = require('./processors.controller');
-const controller = new processorController();
+const ProcessorsController = require('./processors.controller');
+const processorsController = new ProcessorsController();
 
 module.exports = app => {
   app.use('/processors', router);
@@ -16,11 +16,11 @@ module.exports = app => {
     '/subject/:subjectId/data',
     controllerOnly,
     asyncHandler(ensureProcessorAccessToSubject),
-    asyncHandler(async (req, res) => controller.getSubjectData(req, res))
+    asyncHandler(async (req, res) => processorsController.getSubjectData(req, res))
   );
 
   router.get(
     '/contract/details',
-    asyncHandler(async (req, res) => controller.getContractDetails(req, res))
+    asyncHandler(async (req, res) => processorsController.getContractDetails(req, res))
   );
 };

--- a/cg/src/domains/processors/processors.routes.js
+++ b/cg/src/domains/processors/processors.routes.js
@@ -16,7 +16,7 @@ module.exports = app => {
     '/subject/:subjectId/data',
     controllerOnly,
     asyncHandler(ensureProcessorAccessToSubject),
-    asyncHandler(async (req, res) => controller.getData(req, res))
+    asyncHandler(async (req, res) => controller.getSubjectData(req, res))
   );
 
   router.get(

--- a/cg/src/domains/processors/processors.service.js
+++ b/cg/src/domains/processors/processors.service.js
@@ -1,0 +1,128 @@
+const { db } = require('../../db');
+const { 
+  encryptForStorage, 
+  decryptFromStorage, 
+  generateClientKey 
+} = require('../../utils/encryption');
+const {
+  recordErasureByController,
+  recordErasureByProcessor,
+} = require('../../utils/blockchain');
+
+
+class ProcessorsService {
+	constructor(database = db) {
+    this.db = database;
+  }
+
+  async getSubjectData(subjectId) {
+    const [ data ] = await this.db('subjects')
+      .join('subject_keys', 'subjects.id', '=', 'subject_keys.subject_id')
+      .select('personal_data')
+      .select('key')
+      .where({ subject_id: subjectId });
+      
+    if (!data) throw new NotFound('Subject not found');
+    const decryptedData = decryptFromStorage(data.personal_data, data.key);
+    return JSON.parse(decryptedData);
+	 }
+	 
+	// async initializeUser(subjectId, personalData) {
+  //   await this.db.transaction(async trx => {
+  //     await this._initializeUserInTransaction(trx, subjectId, personalData);
+  //   });
+	// }
+	
+	// async _initializeUserInTransaction(trx, subjectId, personalData) {
+  //   const [subject] = await this.db('subjects')
+  //     .transacting(trx)
+  //     .where('id', subjectId)
+  //     .select();
+
+  //   if (!subject) {
+  //     await this._createNewSubject(personalData, trx, subjectId);
+  //   } 
+  //   else {
+  //     await this._updateExistingSubject(trx, subjectId, personalData); 
+  //   }
+	// }
+	
+	// async _createNewSubject(personalData, trx, subjectId) {
+  //   const encryptionKey = generateClientKey();
+  //   const encryptedPersonalData = encryptForStorage(JSON.stringify(personalData), encryptionKey);
+  //   await this.db('subjects')
+  //     .transacting(trx)
+  //     .insert({
+  //       id: subjectId,
+  //       personal_data: encryptedPersonalData,
+  //       direct_marketing: true,
+  //       email_communication: true,
+  //       research: true,
+  //     });
+
+  //   await this._saveSubjectEncryptionKey(trx, subjectId, encryptionKey);
+  // }
+
+	// async _updateExistingSubject(trx, subjectId, personalData) { 
+  //   const [subjectKey] = await this.db('subject_keys')
+  //     .transacting(trx)
+  //     .where('subject_id', subjectId)
+  //     .select();
+
+  //   let encryptionKey;
+  //   if (subjectKey) {
+  //     encryptionKey = subjectKey.key;
+  //   } else {
+  //     encryptionKey = generateClientKey();
+  //     await this._saveSubjectEncryptionKey(trx, subjectId, encryptionKey);
+  //   }
+  //   const encryptedPersonalData = encryptForStorage(JSON.stringify(personalData), encryptionKey);
+  //   await this.db('subjects')
+  //     .transacting(trx)
+  //     .where('id', subjectId)
+  //     .update({
+  //       personal_data: encryptedPersonalData,
+  //       updated_at: this.db.raw('CURRENT_TIMESTAMP')
+  //     });
+  // }
+  
+  // async _saveSubjectEncryptionKey(trx, subjectId, encryptionKey) {
+  //   await this.db('subject_keys')
+  //     .transacting(trx)
+  //     .insert({
+  //       subject_id: subjectId,
+  //       key: encryptionKey
+  //     });
+  // }
+	
+	// async eraseDataAndRevokeConsent(subjectId) {
+  //   await this.db.transaction(async trx => {
+  //     await this.db('subject_keys')
+  //       .transacting(trx)
+  //       .where('subject_id', subjectId)
+  //       .del();
+
+  //     await this.db('subject_processors')
+  //       .transacting(trx)
+  //       .where({
+  //         subject_id: subjectId
+  //       })
+  //       .del();
+
+  //     if (inControllerMode()) {
+  //       winston.info('Emitting erasure event to blockchain');
+  //       await recordErasureByController(subjectId);
+  //     } else {
+  //       await recordErasureByProcessor(subjectId);
+  //     }
+  //   });
+  // }
+
+}
+
+module.exports = ProcessorsService;
+
+
+
+
+  

--- a/cg/src/domains/processors/processors.service.js
+++ b/cg/src/domains/processors/processors.service.js
@@ -1,128 +1,115 @@
 const { db } = require('../../db');
-const { 
-  encryptForStorage, 
-  decryptFromStorage, 
-  generateClientKey 
-} = require('../../utils/encryption');
+const winston = require('winston');
 const {
-  recordErasureByController,
-  recordErasureByProcessor,
-} = require('../../utils/blockchain');
-
+  encryptForStorage,
+  decryptFromStorage,
+  generateClientKey
+} = require('../../utils/encryption');
+const { recordErasureByProcessor } = require('../../utils/blockchain');
+const { NotFound } = require('../../utils/errors');
 
 class ProcessorsService {
-	constructor(database = db) {
+  constructor(database = db) {
     this.db = database;
   }
 
   async getSubjectData(subjectId) {
-    const [ data ] = await this.db('subjects')
+    const [data] = await this.db('subjects')
       .join('subject_keys', 'subjects.id', '=', 'subject_keys.subject_id')
       .select('personal_data')
       .select('key')
       .where({ subject_id: subjectId });
-      
+
     if (!data) throw new NotFound('Subject not found');
     const decryptedData = decryptFromStorage(data.personal_data, data.key);
     return JSON.parse(decryptedData);
-	 }
-	 
-	// async initializeUser(subjectId, personalData) {
-  //   await this.db.transaction(async trx => {
-  //     await this._initializeUserInTransaction(trx, subjectId, personalData);
-  //   });
-	// }
-	
-	// async _initializeUserInTransaction(trx, subjectId, personalData) {
-  //   const [subject] = await this.db('subjects')
-  //     .transacting(trx)
-  //     .where('id', subjectId)
-  //     .select();
+  }
 
-  //   if (!subject) {
-  //     await this._createNewSubject(personalData, trx, subjectId);
-  //   } 
-  //   else {
-  //     await this._updateExistingSubject(trx, subjectId, personalData); 
-  //   }
-	// }
-	
-	// async _createNewSubject(personalData, trx, subjectId) {
-  //   const encryptionKey = generateClientKey();
-  //   const encryptedPersonalData = encryptForStorage(JSON.stringify(personalData), encryptionKey);
-  //   await this.db('subjects')
-  //     .transacting(trx)
-  //     .insert({
-  //       id: subjectId,
-  //       personal_data: encryptedPersonalData,
-  //       direct_marketing: true,
-  //       email_communication: true,
-  //       research: true,
-  //     });
+  async initializeUser(subjectId, personalData) {
+    await this.db.transaction(async trx => {
+      await this._initializeUserInTransaction(trx, subjectId, personalData);
+    });
+  }
 
-  //   await this._saveSubjectEncryptionKey(trx, subjectId, encryptionKey);
-  // }
+  async _initializeUserInTransaction(trx, subjectId, personalData) {
+    const [subject] = await this.db('subjects')
+      .transacting(trx)
+      .where('id', subjectId)
+      .select();
 
-	// async _updateExistingSubject(trx, subjectId, personalData) { 
-  //   const [subjectKey] = await this.db('subject_keys')
-  //     .transacting(trx)
-  //     .where('subject_id', subjectId)
-  //     .select();
+    if (!subject) {
+      await this._createNewSubject(personalData, trx, subjectId);
+    } else {
+      await this._updateExistingSubject(trx, subjectId, personalData);
+    }
+  }
 
-  //   let encryptionKey;
-  //   if (subjectKey) {
-  //     encryptionKey = subjectKey.key;
-  //   } else {
-  //     encryptionKey = generateClientKey();
-  //     await this._saveSubjectEncryptionKey(trx, subjectId, encryptionKey);
-  //   }
-  //   const encryptedPersonalData = encryptForStorage(JSON.stringify(personalData), encryptionKey);
-  //   await this.db('subjects')
-  //     .transacting(trx)
-  //     .where('id', subjectId)
-  //     .update({
-  //       personal_data: encryptedPersonalData,
-  //       updated_at: this.db.raw('CURRENT_TIMESTAMP')
-  //     });
-  // }
-  
-  // async _saveSubjectEncryptionKey(trx, subjectId, encryptionKey) {
-  //   await this.db('subject_keys')
-  //     .transacting(trx)
-  //     .insert({
-  //       subject_id: subjectId,
-  //       key: encryptionKey
-  //     });
-  // }
-	
-	// async eraseDataAndRevokeConsent(subjectId) {
-  //   await this.db.transaction(async trx => {
-  //     await this.db('subject_keys')
-  //       .transacting(trx)
-  //       .where('subject_id', subjectId)
-  //       .del();
+  async _createNewSubject(personalData, trx, subjectId) {
+    const encryptionKey = generateClientKey();
+    const encryptedPersonalData = encryptForStorage(JSON.stringify(personalData), encryptionKey);
+    await this.db('subjects')
+      .transacting(trx)
+      .insert({
+        id: subjectId,
+        personal_data: encryptedPersonalData,
+        direct_marketing: true,
+        email_communication: true,
+        research: true
+      });
 
-  //     await this.db('subject_processors')
-  //       .transacting(trx)
-  //       .where({
-  //         subject_id: subjectId
-  //       })
-  //       .del();
+    await this._saveSubjectEncryptionKey(trx, subjectId, encryptionKey);
+  }
 
-  //     if (inControllerMode()) {
-  //       winston.info('Emitting erasure event to blockchain');
-  //       await recordErasureByController(subjectId);
-  //     } else {
-  //       await recordErasureByProcessor(subjectId);
-  //     }
-  //   });
-  // }
+  async _updateExistingSubject(trx, subjectId, personalData) {
+    const [subjectKey] = await this.db('subject_keys')
+      .transacting(trx)
+      .where('subject_id', subjectId)
+      .select();
 
+    let encryptionKey;
+    if (subjectKey) {
+      encryptionKey = subjectKey.key;
+    } else {
+      encryptionKey = generateClientKey();
+      await this._saveSubjectEncryptionKey(trx, subjectId, encryptionKey);
+    }
+    const encryptedPersonalData = encryptForStorage(JSON.stringify(personalData), encryptionKey);
+    await this.db('subjects')
+      .transacting(trx)
+      .where('id', subjectId)
+      .update({
+        personal_data: encryptedPersonalData,
+        updated_at: this.db.raw('CURRENT_TIMESTAMP')
+      });
+  }
+
+  async _saveSubjectEncryptionKey(trx, subjectId, encryptionKey) {
+    await this.db('subject_keys')
+      .transacting(trx)
+      .insert({
+        subject_id: subjectId,
+        key: encryptionKey
+      });
+  }
+
+  async eraseDataAndRevokeConsent(subjectId) {
+    await this.db.transaction(async trx => {
+      await this.db('subject_keys')
+        .transacting(trx)
+        .where('subject_id', subjectId)
+        .del();
+
+      await this.db('subject_processors')
+        .transacting(trx)
+        .where({
+          subject_id: subjectId
+        })
+        .del();
+
+      winston.info('Emitting erasure event to blockchain');
+      await recordErasureByProcessor(subjectId);
+    });
+  }
 }
 
 module.exports = ProcessorsService;
-
-
-
-
-  

--- a/cg/src/domains/processors/subjects.service.js
+++ b/cg/src/domains/processors/subjects.service.js
@@ -8,7 +8,7 @@ const {
 const { recordErasureByProcessor } = require('../../utils/blockchain');
 const { NotFound } = require('../../utils/errors');
 
-class ProcessorsService {
+class SubjectsService {
   constructor(database = db) {
     this.db = database;
   }
@@ -112,4 +112,4 @@ class ProcessorsService {
   }
 }
 
-module.exports = ProcessorsService;
+module.exports = SubjectsService;


### PR DESCRIPTION
Closes #329 Closes #311 

Creates a processors service in the processors domain, separating the processors domain from the subjects domain. They have essentially the same code with a few slightly differences.
Also calls the smart contract from the data-access endpoint in the subjects domain, which was missing.
Tests are passing, but I want to test it more in Postman before considering merging.
Anyways it's good to start receiving reviews