### PR TITLE
Add management endpoint to get a subject's restrictions

### DIFF
--- a/cg/src/domains/management/management.routes.js
+++ b/cg/src/domains/management/management.routes.js
@@ -31,7 +31,8 @@ const {
   listSubjectsValidator,
   listRectificationRequestsValidator,
   getRectificiationValidator,
-  updateRectificationStatusValidator
+  updateRectificationStatusValidator,
+  getSubjectRestrictionsValidator
 } = require('./subjects/subjects.validators');
 
 const {
@@ -103,6 +104,12 @@ module.exports = app => {
     '/subjects/rectification-requests/:rectificationRequestId/update-status',
     updateRectificationStatusValidator,
     asyncHandler(async (req, res) => subjectsController.updateRectificationRequestStatus(req, res))
+  );
+
+  router.get(
+    '/subjects/:subjectId/get-restrictions',
+    getSubjectRestrictionsValidator,
+    asyncHandler(async (req, res) => subjectsController.getSubjectRestrictions(req, res))
   );
 
   router.get(

--- a/cg/src/domains/management/subjects/subjects.controller.js
+++ b/cg/src/domains/management/subjects/subjects.controller.js
@@ -58,6 +58,13 @@ class SubjectsController {
       )
     );
   }
+
+  async getSubjectRestrictions(req, res) {
+    const subjectRestrictions = await this.subjectsService.getSubjectRestrictions(
+      req.params.subjectId
+    );
+    res.json(subjectRestrictions);
+  }
 }
 
 module.exports = SubjectsController;

--- a/cg/src/domains/management/subjects/subjects.service.js
+++ b/cg/src/domains/management/subjects/subjects.service.js
@@ -65,7 +65,7 @@ class SubjectsService {
     };
   }
 
-  async listRectificationRequests(requestedPage = 1) { 
+  async listRectificationRequests(requestedPage = 1) {
     const [{ total_items }] = await this.db('rectification_requests')
       .where('status', RECTIFICATION_STATUSES.PENDING)
       .join('subject_keys', 'rectification_requests.subject_id', 'subject_keys.subject_id')
@@ -83,7 +83,7 @@ class SubjectsService {
       .where('status', RECTIFICATION_STATUSES.PENDING)
       .join('subject_keys', 'rectification_requests.subject_id', 'subject_keys.subject_id')
       .limit(PAGE_SIZE)
-      .offset((requestedPage - 1 ) * PAGE_SIZE);
+      .offset((requestedPage - 1) * PAGE_SIZE);
 
     return {
       data: requests,
@@ -193,6 +193,15 @@ class SubjectsService {
       createdAt: requestData.rectification_request_created_at,
       status: requestData.status
     };
+  }
+
+  async getSubjectRestrictions(subjectId) {
+    const [subjectRestrictions] = await this.db('subjects')
+      .where('id', subjectId)
+      .select('direct_marketing', 'email_communication', 'research');
+
+    if (!subjectRestrictions) throw new NotFound('Subject not found');
+    return subjectRestrictions;
   }
 }
 

--- a/cg/src/domains/management/subjects/subjects.validators.js
+++ b/cg/src/domains/management/subjects/subjects.validators.js
@@ -42,9 +42,19 @@ const getRectificiationValidator = celebrate({
   }
 });
 
+const getSubjectRestrictionsValidator = celebrate({
+  params: {
+    subjectId: Joi.string()
+      .alphanum()
+      .length(66) // length of a sha3 hash with the prepended '0x'
+      .required()
+  }
+});
+
 module.exports = {
   listSubjectsValidator,
   listRectificationRequestsValidator,
   updateRectificationStatusValidator,
-  getRectificiationValidator
+  getRectificiationValidator,
+  getSubjectRestrictionsValidator
 };


### PR DESCRIPTION
Closes #328 

Create a management endpoint to get a subject's restrictions.
I want to discuss about this, not sure this is necessary or relevant. 
We have an endpoint to list the subjects, the restriction information could be returned there instead. Also, the idea of a manager being able to pinpoint a single subject to see his restrictions has its downsides.
Let's discuss about this Monday