### PR TITLE
Implementing a complete REST API

### DIFF
--- a/admin/src/containers/Dashboard/Widgets/SubjectsList.js
+++ b/admin/src/containers/Dashboard/Widgets/SubjectsList.js
@@ -14,7 +14,7 @@ export class SubjectsListContainer extends React.Component {
 
   fetchSubjects(page = 1) {
     this.setState({ errorState: false, loading: true });
-    internalFetch(`${config.API_URL}/api/management/subjects/list?page=${page}`)
+    internalFetch(`${config.API_URL}/api/management/subjects?page=${page}`)
       .then(({ data, paging }) => {
         this.setState({ subjects: data, paging, loading: false });
       })

--- a/admin/src/containers/Data/AttributesConfigContext.js
+++ b/admin/src/containers/Data/AttributesConfigContext.js
@@ -33,8 +33,8 @@ export class AttributesConfigProvider extends Component {
 
   updateConfig = async config => {
     this.setState({ isBusy: true });
-    await internalFetch(`${AppConfig.API_URL}/api/management/data/attributes-config/update`, {
-      method: 'POST',
+    await internalFetch(`${AppConfig.API_URL}/api/management/data/attributes-config`, {
+      method: 'PUT',
       body: JSON.stringify(config)
     });
     this.setState({ isBusy: false, config });

--- a/admin/src/containers/Data/AttributesConfigContext.test.js
+++ b/admin/src/containers/Data/AttributesConfigContext.test.js
@@ -66,10 +66,10 @@ describe('AttributesConfigProvider', () => {
     const provider = setupProvider();
     provider.state().updateConfig(EXAMPLE_CONFIG);
     expect(internalFetch).toHaveBeenCalledWith(
-      `${AppConfig.API_URL}/api/management/data/attributes-config/update`,
+      `${AppConfig.API_URL}/api/management/data/attributes-config`,
       {
         body: JSON.stringify(EXAMPLE_CONFIG),
-        method: 'POST'
+        method: 'PUT'
       }
     );
   });

--- a/admin/src/containers/Processors/ProcessorsContext.js
+++ b/admin/src/containers/Processors/ProcessorsContext.js
@@ -79,26 +79,26 @@ export class ProcessorsProvider extends Component {
   };
 
   _getProcessors() {
-    return internalFetch(`${config.API_URL}/api/management/processors/list`);
+    return internalFetch(`${config.API_URL}/api/management/processors`);
   }
 
   _addProcessor(processor) {
-    return internalFetch(`${config.API_URL}/api/management/processors/add`, {
+    return internalFetch(`${config.API_URL}/api/management/processors`, {
       method: 'POST',
       body: JSON.stringify(processor)
     });
   }
 
   _updateProcessor(processor) {
-    return internalFetch(`${config.API_URL}/api/management/processors/update`, {
-      method: 'POST',
+    return internalFetch(`${config.API_URL}/api/management/processors`, {
+      method: 'PUT',
       body: JSON.stringify(processor)
     });
   }
 
   async _deleteProcessor(processorId) {
-    await internalFetch(`${config.API_URL}/api/management/processors/remove`, {
-      method: 'POST',
+    await internalFetch(`${config.API_URL}/api/management/processors`, {
+      method: 'DELETE',
       body: JSON.stringify({
         processorIds: [processorId]
       })

--- a/admin/src/containers/Rectifications/RectificationsContext.js
+++ b/admin/src/containers/Rectifications/RectificationsContext.js
@@ -39,9 +39,9 @@ export class RectificationsProvider extends Component {
   approveRectification = async id => {
     try {
       await internalFetch(
-        `${config.API_URL}/api/management/subjects/rectification-requests/${id}/update-status`,
+        `${config.API_URL}/api/management/subjects/rectification-requests/${id}`,
         {
-          method: 'POST',
+          method: 'PUT',
           body: JSON.stringify({
             status: 'APPROVED'
           })
@@ -68,7 +68,7 @@ export class RectificationsProvider extends Component {
   async _getPendingRectifications(page = 1) {
     return this._mapRectificationResults(
       await internalFetch(
-        `${config.API_URL}/api/management/subjects/rectification-requests/list?page=${page}`
+        `${config.API_URL}/api/management/subjects/rectification-requests?page=${page}`
       )
     );
   }

--- a/admin/src/containers/Rectifications/RectificationsContext.test.js
+++ b/admin/src/containers/Rectifications/RectificationsContext.test.js
@@ -189,7 +189,7 @@ describe('RectificationsProvider', () => {
       internalFetch.mockImplementation(url => {
         if (lodash.includes(url, 'rectification-requests/archive')) {
           return Promise.resolve(newProcessed);
-        } else if (lodash.includes(url, 'rectification-requests/list')) {
+        } else if (lodash.includes(url, 'rectification-requests')) {
           return Promise.resolve(newPending);
         } else {
           return Promise.resolve({ success: true });

--- a/admin/src/containers/Users/UsersContext.js
+++ b/admin/src/containers/Users/UsersContext.js
@@ -66,7 +66,7 @@ export class UsersProvider extends Component {
   }
 
   _registerUser(username, password) {
-    return internalFetch(`${config.API_URL}/api/management/users/register`, {
+    return internalFetch(`${config.API_URL}/api/management/users`, {
       method: 'POST',
       body: JSON.stringify({
         username,
@@ -76,8 +76,8 @@ export class UsersProvider extends Component {
   }
 
   async _deleteUser(userId) {
-    await internalFetch(`${config.API_URL}/api/management/users/${userId}/remove`, {
-      method: 'POST'
+    await internalFetch(`${config.API_URL}/api/management/users/${userId}`, {
+      method: 'DELETE'
     });
   }
 

--- a/cg/docs/CG_API.md
+++ b/cg/docs/CG_API.md
@@ -18,7 +18,7 @@
       - [GET Get data status](#get-get-data-status)
         - [Headers](#headers-1)
         - [Example Request](#example-request-1)
-      - [POST Erase data](#post-erase-data)
+      - [DELETE Erase data](#delete-erase-data)
         - [Headers](#headers-2)
         - [Example Request](#example-request-2)
       - [POST Give consent](#post-give-consent)
@@ -101,7 +101,7 @@ You can reach out to us or open an issue on https://github.com/clevertech/ClearG
 Access Subject's data and Processors Ids associated to it.
 
 ```
-{{cg_base_url}}/api/subject/access-data
+{{cg_base_url}}/api/subject/data
 ```
 
 ##### Headers
@@ -114,7 +114,7 @@ Access Subject's data and Processors Ids associated to it.
 
 ```
 curl --request GET \
-  --url 'http://{{cg_base_url}}/api/subject/access-data' \
+  --url 'http://{{cg_base_url}}/api/subject/data' \
   --header 'Content-Type: application/json'
 ```
 
@@ -123,7 +123,7 @@ curl --request GET \
 Show data status by specific subject ordered by Processor Id
 
 ```
-{{cg_base_url}}/api/subject/data-status
+{{cg_base_url}}/api/subject/data/status
 ```
 
 ##### Headers
@@ -135,16 +135,16 @@ Show data status by specific subject ordered by Processor Id
 ##### Example Request
 ```
 curl --request GET \
-  --url 'http://{{cg_base_url}}/api/subject/data-status' \
+  --url 'http://{{cg_base_url}}/api/subject/data/status' \
   --header 'Content-Type: application/json'
 ```
 
-#### POST Erase data
+#### DELETE Erase data
 
 Delete Subject's data from the backend
 
 ```
-{{cg_base_url}}/api/subject/erase-data
+{{cg_base_url}}/api/subject/data
 ```
 
 ##### Headers
@@ -155,8 +155,8 @@ Delete Subject's data from the backend
 
 ##### Example Request
 ```
-curl --request POST \
-  --url 'http://{{cg_base_url}}/api/subject/erase-data' \
+curl --request DELETE \
+  --url 'http://{{cg_base_url}}/api/subject/data' \
   --header 'Content-Type: application/json'
 ```
 
@@ -165,7 +165,7 @@ curl --request POST \
 Handles right to access of different processors to Subject's data. The list of Processors Ids should be always explicit. The list of all the processors should be fetch from `GET List processors` endpoint.
 
 ```
-{{cg_base_url}}/api/subject/give-consent
+{{cg_base_url}}/api/subject/consent
 ```
 
 ##### Headers
@@ -184,7 +184,7 @@ Handles right to access of different processors to Subject's data. The list of P
 ##### Example Request
 ```
 curl --request POST \
-  --url 'http://{{cg_base_url}}/api/subject/give-consent' \
+  --url 'http://{{cg_base_url}}/api/subject/consent' \
   --header 'Content-Type: application/json' \
   --data '{
 	"personalData": {

--- a/cg/src/domains/management/management.routes.js
+++ b/cg/src/domains/management/management.routes.js
@@ -79,13 +79,13 @@ module.exports = app => {
   );
 
   router.get(
-    '/subjects/list',
+    '/subjects',
     listSubjectsValidator,
     asyncHandler(async (req, res) => subjectsController.listSubjects(req, res))
   );
 
   router.get(
-    '/subjects/rectification-requests/list',
+    '/subjects/rectification-requests',
     listRectificationRequestsValidator,
     asyncHandler(async (req, res) => subjectsController.listRectificationRequests(req, res))
   );
@@ -106,43 +106,43 @@ module.exports = app => {
 
   router.get('/events', asyncHandler(async (req, res) => statsController.events(req, res)));
 
-  router.post(
-    '/subjects/rectification-requests/:rectificationRequestId/update-status',
+  router.put(
+    '/subjects/rectification-requests/:rectificationRequestId',
     updateRectificationStatusValidator,
     asyncHandler(async (req, res) => subjectsController.updateRectificationRequestStatus(req, res))
   );
 
   router.get(
-    '/processors/list',
+    '/processors',
     asyncHandler(async (req, res) => processorsController.listProcessors(req, res))
   );
 
   router.post(
-    '/processors/add',
+    '/processors',
     addProcessorValidator,
     asyncHandler(async (req, res) => processorsController.addProcessor(req, res))
   );
 
-  router.post(
-    '/processors/update',
+  router.put(
+    '/processors',
     updateProcessorValidator,
     asyncHandler(async (req, res) => processorsController.updateProcessor(req, res))
   );
 
-  router.post(
-    '/processors/remove',
+  router.delete(
+    '/processors',
     deleteProcessorValidator,
     asyncHandler(async (req, res) => processorsController.removeProcessors(req, res))
   );
 
   router.post(
-    '/users/register',
+    '/users',
     usersRegistrationValidator,
     asyncHandler(async (req, res) => usersController.register(req, res))
   );
 
-  router.post(
-    '/users/:userId/remove',
+  router.delete(
+    '/users/:userId',
     usersRemovalValidator,
     asyncHandler(async (req, res) => usersController.remove(req, res))
   );
@@ -153,8 +153,8 @@ module.exports = app => {
     asyncHandler(async (req, res) => usersController.updatePassword(req, res))
   );
 
-  router.post(
-    '/data/attributes-config/update',
+  router.put(
+    '/data/attributes-config',
     updateAttributesConfigValidator,
     asyncHandler(async (req, res) => dataController.updateAttributesConfig(req, res))
   );

--- a/cg/src/domains/processors/processors.requests.js
+++ b/cg/src/domains/processors/processors.requests.js
@@ -15,7 +15,7 @@ async function getDataForSubject(subjectId) {
 }
 
 async function getRestrictionsForSubject(subjectId) {
-  return await fetch(`${CONTROLLER_URL}/api/processors/subject/${subjectId}/get-restrictions`, {
+  return await fetch(`${CONTROLLER_URL}/api/processors/subject/${subjectId}/restrictions`, {
     method: 'GET',
     headers: {
       Authorization: `Bearer ${PROCESSOR_JWT}`

--- a/cg/src/domains/processors/processors.routes.js
+++ b/cg/src/domains/processors/processors.routes.js
@@ -25,14 +25,14 @@ module.exports = app => {
   );
 
   router.get(
-    '/subject/:subjectId/get-restrictions',
+    '/subject/:subjectId/restrictions',
     controllerOnly,
     asyncHandler(ensureProcessorAccessToSubject),
     asyncHandler(async (req, res) => processorsController.getSubjectRestrictions(req, res))
   );
 
   router.get(
-    '/subject/:subjectId/get-objection',
+    '/subject/:subjectId/objection',
     controllerOnly,
     asyncHandler(ensureProcessorAccessToSubject),
     asyncHandler(async (req, res) => processorsController.getSubjectObjection(req, res))

--- a/cg/src/domains/subjects/subjects.routes.js
+++ b/cg/src/domains/subjects/subjects.routes.js
@@ -54,44 +54,44 @@ module.exports = app => {
   router.use(verifyJWT, requireSubjectId, transformSubjectId);
 
   router.post(
-    '/give-consent',
+    '/consent',
     controllerOnly,
     giveConsentValidator,
     asyncHandler(async (req, res) => subjectsController.giveConsent(req, res))
   );
 
-  router.post(
-    '/update-consent',
+  router.put(
+    '/consent',
     controllerOnly,
     updateConsentValidator,
     asyncHandler(async (req, res) => subjectsController.updateConsent(req, res))
   );
 
   router.get(
-    '/access-data',
+    '/data',
     asyncHandler(async (req, res) => subjectsController.requestDataAccess(req, res))
   );
 
   router.get(
-    '/data-status',
+    '/data/status',
     asyncHandler(async (req, res) => subjectsController.getPersonalDataStatus(req, res))
   );
 
   router.post(
-    '/initiate-rectification',
+    '/rectification',
     rectificationValidator,
     asyncHandler(async (req, res) => subjectsController.initiateRectification(req, res))
   );
 
   router.post(
-    '/restrict',
+    '/restrictions',
     controllerOnly,
     restrictionValidator,
     asyncHandler(async (req, res) => subjectsController.restrict(req, res))
   );
 
   router.get(
-    '/get-restrictions',
+    '/restrictions',
     asyncHandler(async (req, res) => subjectsController.getRestrictions(req, res))
   );
 
@@ -103,29 +103,29 @@ module.exports = app => {
   );
 
   router.get(
-    '/get-objection',
+    '/objection',
     asyncHandler(async (req, res) => subjectsController.getObjection(req, res))
   );
 
   router.post(
-    '/data-shares/create',
+    '/data-shares',
     createDataShareValidator,
     asyncHandler(async (req, res) => dataShareController.createDataShare(req, res))
   );
 
   router.get(
-    '/data-shares/list',
+    '/data-shares',
     asyncHandler(async (req, res) => dataShareController.getDataShares(req, res))
   );
 
-  router.post(
-    '/data-shares/:dataShareId/remove',
+  router.delete(
+    '/data-shares/:dataShareId',
     removeDataShareValidator,
     asyncHandler(async (req, res) => dataShareController.removeDataShare(req, res))
   );
 
-  router.post(
-    '/erase-data',
+  router.delete(
+    '/data',
     controllerOnly,
     asyncHandler(async (req, res) => subjectsController.eraseData(req, res))
   );

--- a/cg/test/management/data.api.spec.js
+++ b/cg/test/management/data.api.spec.js
@@ -58,8 +58,8 @@ describe('Data attributes config API', () => {
     };
     const newConfig = { ...TEST_CONFIG, name };
 
-    await fetch('/api/management/data/attributes-config/update', {
-      method: 'POST',
+    await fetch('/api/management/data/attributes-config', {
+      method: 'PUT',
       headers: {
         Authorization: `Bearer ${token}`
       },
@@ -85,8 +85,8 @@ describe('Data attributes config API', () => {
     };
     const newConfig = { ...TEST_CONFIG, name };
 
-    const res = await fetch('/api/management/data/attributes-config/update', {
-      method: 'POST',
+    const res = await fetch('/api/management/data/attributes-config', {
+      method: 'PUT',
       headers: {
         Authorization: `Bearer ${token}`
       },

--- a/cg/test/management/processors.api.spec.js
+++ b/cg/test/management/processors.api.spec.js
@@ -17,8 +17,8 @@ afterAll(closeResources);
 
 describe('List processors', () => {
   it('should not allow listing processors without a token', async () => {
-    const res = await fetch('/api/management/processors/remove', {
-      method: 'POST'
+    const res = await fetch('/api/management/processors', {
+      method: 'DELETE'
     });
 
     expect(res.ok).toBeFalsy();
@@ -48,7 +48,7 @@ describe('List processors', () => {
       address: '0x0000000000000000000000000000000000000003'
     });
 
-    const res = await fetch('/api/management/processors/list', {
+    const res = await fetch('/api/management/processors', {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${token}`
@@ -78,7 +78,7 @@ describe('List processors', () => {
 
 describe('Add processor', () => {
   it('should not allow adding processors without a token', async () => {
-    const res = await fetch('/api/management/processors/add', {
+    const res = await fetch('/api/management/processors', {
       method: 'POST'
     });
 
@@ -89,7 +89,7 @@ describe('Add processor', () => {
   it('should not allow empty body', async () => {
     const token = await managementJWT.sign({ id: 1 });
 
-    const res = await fetch('/api/management/processors/add', {
+    const res = await fetch('/api/management/processors', {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${token}`
@@ -105,7 +105,7 @@ describe('Add processor', () => {
   it('should not allow processor without a name', async () => {
     const token = await managementJWT.sign({ id: 1 });
 
-    const res = await fetch('/api/management/processors/add', {
+    const res = await fetch('/api/management/processors', {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${token}`
@@ -123,7 +123,7 @@ describe('Add processor', () => {
   it('should not allow processor with ID', async () => {
     const token = await managementJWT.sign({ id: 1 });
 
-    const res = await fetch('/api/management/processors/add', {
+    const res = await fetch('/api/management/processors', {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${token}`
@@ -146,7 +146,7 @@ describe('Add processor', () => {
   it('should not allow processor with arbitrary key', async () => {
     const token = await managementJWT.sign({ id: 1 });
 
-    const res = await fetch('/api/management/processors/add', {
+    const res = await fetch('/api/management/processors', {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${token}`
@@ -169,7 +169,7 @@ describe('Add processor', () => {
   it('should not allow improper address format', async () => {
     const token = await managementJWT.sign({ id: 1 });
 
-    const res = await fetch('/api/management/processors/add', {
+    const res = await fetch('/api/management/processors', {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${token}`
@@ -188,7 +188,7 @@ describe('Add processor', () => {
   it('should not allow scopes that are not an array', async () => {
     const token = await managementJWT.sign({ id: 1 });
 
-    const res = await fetch('/api/management/processors/add', {
+    const res = await fetch('/api/management/processors', {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${token}`
@@ -207,7 +207,7 @@ describe('Add processor', () => {
   it('should verify the types of name parameter', async () => {
     const token = await managementJWT.sign({ id: 1 });
 
-    const res = await fetch('/api/management/processors/add', {
+    const res = await fetch('/api/management/processors', {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${token}`
@@ -233,7 +233,7 @@ describe('Add processor', () => {
       address: '0x00000000000000000000000000000000000000A5'
     };
 
-    const res = await fetch('/api/management/processors/add', {
+    const res = await fetch('/api/management/processors', {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${token}`
@@ -268,8 +268,8 @@ describe('Add processor', () => {
 
 describe('Update processor', () => {
   it('should not allow the update of the processor without a token', async () => {
-    const res = await fetch('/api/management/processors/update', {
-      method: 'POST'
+    const res = await fetch('/api/management/processors', {
+      method: 'PUT'
     });
 
     expect(res.ok).toBeFalsy();
@@ -279,8 +279,8 @@ describe('Update processor', () => {
   it('should not allow empty body', async () => {
     const token = await managementJWT.sign({ id: 1 });
 
-    const res = await fetch('/api/management/processors/update', {
-      method: 'POST',
+    const res = await fetch('/api/management/processors', {
+      method: 'PUT',
       headers: {
         Authorization: `Bearer ${token}`
       },
@@ -295,8 +295,8 @@ describe('Update processor', () => {
   it('should not allow processor without an ID', async () => {
     const token = await managementJWT.sign({ id: 1 });
 
-    const res = await fetch('/api/management/processors/update', {
-      method: 'POST',
+    const res = await fetch('/api/management/processors', {
+      method: 'PUT',
       headers: {
         Authorization: `Bearer ${token}`
       },
@@ -314,8 +314,8 @@ describe('Update processor', () => {
   it('should not allow updating an address', async () => {
     const token = await managementJWT.sign({ id: 1 });
 
-    const res = await fetch('/api/management/processors/update', {
-      method: 'POST',
+    const res = await fetch('/api/management/processors', {
+      method: 'PUT',
       headers: {
         Authorization: `Bearer ${token}`
       },
@@ -338,8 +338,8 @@ describe('Update processor', () => {
   it('should return not found when processor does not exist', async () => {
     const token = await managementJWT.sign({ id: 1 });
 
-    const res = await fetch('/api/management/processors/update', {
-      method: 'POST',
+    const res = await fetch('/api/management/processors', {
+      method: 'PUT',
       headers: {
         Authorization: `Bearer ${token}`
       },
@@ -369,8 +369,8 @@ describe('Update processor', () => {
       scopes: JSON.stringify(['email', 'first name'])
     });
 
-    const res = await fetch('/api/management/processors/update', {
-      method: 'POST',
+    const res = await fetch('/api/management/processors', {
+      method: 'PUT',
       headers: {
         Authorization: `Bearer ${token}`
       },
@@ -410,8 +410,8 @@ describe('Update processor', () => {
       scopes: JSON.stringify(['email', 'first name'])
     });
 
-    const res = await fetch('/api/management/processors/update', {
-      method: 'POST',
+    const res = await fetch('/api/management/processors', {
+      method: 'PUT',
       headers: {
         Authorization: `Bearer ${token}`
       },
@@ -439,8 +439,8 @@ describe('Update processor', () => {
 
 describe('Remove processors', () => {
   it('should not allow the delete processors without a token', async () => {
-    const res = await fetch('/api/management/processors/remove', {
-      method: 'POST'
+    const res = await fetch('/api/management/processors', {
+      method: 'DELETE'
     });
 
     expect(res.ok).toBeFalsy();
@@ -452,8 +452,8 @@ describe('Remove processors', () => {
       id: 1
     });
 
-    const res = await fetch('/api/management/processors/remove', {
-      method: 'POST',
+    const res = await fetch('/api/management/processors', {
+      method: 'DELETE',
       headers: {
         Authorization: `Bearer ${token}`
       }
@@ -469,8 +469,8 @@ describe('Remove processors', () => {
       id: 1
     });
 
-    const res = await fetch('/api/management/processors/remove', {
-      method: 'POST',
+    const res = await fetch('/api/management/processors', {
+      method: 'DELETE',
       headers: {
         Authorization: `Bearer ${token}`,
         body: {}
@@ -487,8 +487,8 @@ describe('Remove processors', () => {
       id: 1
     });
 
-    const res = await fetch('/api/management/processors/remove', {
-      method: 'POST',
+    const res = await fetch('/api/management/processors', {
+      method: 'DELETE',
       headers: {
         Authorization: `Bearer ${token}`
       },
@@ -546,8 +546,8 @@ describe('Remove processors', () => {
 
     const removedProcessorIds = [612, 655];
 
-    const res = await fetch('/api/management/processors/remove', {
-      method: 'POST',
+    const res = await fetch('/api/management/processors', {
+      method: 'DELETE',
       headers: {
         Authorization: `Bearer ${token}`
       },

--- a/cg/test/management/stats.api.spec.js
+++ b/cg/test/management/stats.api.spec.js
@@ -98,7 +98,7 @@ describe('Stats endpoint', () => {
     });
 
     const token1 = await subjectJWT.sign({ subjectId: '1aadddsas21322b' });
-    await fetch('/api/subject/give-consent', {
+    await fetch('/api/subject/consent', {
       method: 'POST',
       body: {
         personalData: { name: 'dan' },
@@ -110,7 +110,7 @@ describe('Stats endpoint', () => {
     });
 
     const token2 = await subjectJWT.sign({ subjectId: '1aadddsas22322b' });
-    await fetch('/api/subject/give-consent', {
+    await fetch('/api/subject/consent', {
       method: 'POST',
       body: {
         personalData: { name: 'dave' },
@@ -122,8 +122,8 @@ describe('Stats endpoint', () => {
     });
 
     // When statement
-    await fetch('/api/subject/erase-data', {
-      method: 'POST',
+    await fetch('/api/subject/data', {
+      method: 'DELETE',
       headers: {
         Authorization: `Bearer ${token2}`
       }

--- a/cg/test/management/subjects.api.spec.js
+++ b/cg/test/management/subjects.api.spec.js
@@ -76,7 +76,7 @@ async function createSubjectWithRectification(overrides = {}) {
 describe('List subjects that have given consent', () => {
   it('should not allow a manager to list subjects without a manager JWT', async () => {
     //GIVEN AND WHEN
-    const res = await fetch('/api/management/subjects/list', {
+    const res = await fetch('/api/management/subjects', {
       method: 'GET',
       headers: {}
     });
@@ -93,7 +93,7 @@ describe('List subjects that have given consent', () => {
 
   it('should not allow a manager to list subjects with an invalid manager JWT', async () => {
     //GIVEN AND WHEN
-    const res = await fetch('/api/management/subjects/list', {
+    const res = await fetch('/api/management/subjects', {
       method: 'GET',
       headers: {
         Authorization: `invalid_token`
@@ -136,7 +136,7 @@ describe('List subjects that have given consent', () => {
 
     //WHEN
     const managementToken = await managementJWT.sign({ id: 1 });
-    const res = await fetch('/api/management/subjects/list', {
+    const res = await fetch('/api/management/subjects', {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${managementToken}`
@@ -184,7 +184,7 @@ describe('List subjects that have given consent', () => {
 
     //WHEN
     const managementToken = await managementJWT.sign({ id: 1 });
-    const res = await fetch('/api/management/subjects/list', {
+    const res = await fetch('/api/management/subjects', {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${managementToken}`
@@ -254,7 +254,7 @@ describe('List subjects that have given consent', () => {
 
     //WHEN
     const managementToken = await managementJWT.sign({ id: 1 });
-    const res = await fetch('/api/management/subjects/list', {
+    const res = await fetch('/api/management/subjects', {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${managementToken}`
@@ -292,7 +292,7 @@ describe('List subjects that have given consent', () => {
     //WHEN
     const managementToken = await managementJWT.sign({ id: 1 });
 
-    const res = await fetch('/api/management/subjects/list', {
+    const res = await fetch('/api/management/subjects', {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${managementToken}`
@@ -309,7 +309,7 @@ describe('List subjects that have given consent', () => {
     //WHEN
     const managementToken = await managementJWT.sign({ id: 1 });
 
-    const res = await fetch('/api/management/subjects/list?page=-1', {
+    const res = await fetch('/api/management/subjects?page=-1', {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${managementToken}`
@@ -326,7 +326,7 @@ describe('List subjects that have given consent', () => {
     //WHEN
     const managementToken = await managementJWT.sign({ id: 1 });
 
-    const res = await fetch('/api/management/subjects/list?page=0', {
+    const res = await fetch('/api/management/subjects?page=0', {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${managementToken}`
@@ -343,7 +343,7 @@ describe('List subjects that have given consent', () => {
     //WHEN
     const managementToken = await managementJWT.sign({ id: 1 });
 
-    const res = await fetch('/api/management/subjects/list?page=99999999999999', {
+    const res = await fetch('/api/management/subjects?page=99999999999999', {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${managementToken}`
@@ -363,7 +363,7 @@ describe('List subjects that have given consent', () => {
   it('should not allow a page query without an integer page number', async () => {
     //WHEN
     const managementToken = await managementJWT.sign({ id: 1 });
-    const res = await fetch('/api/management/subjects/list?page=string', {
+    const res = await fetch('/api/management/subjects?page=string', {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${managementToken}`
@@ -424,7 +424,7 @@ describe('List subjects that have given consent', () => {
 
     //WHEN
     const managementToken = await managementJWT.sign({ id: 1 });
-    const res = await fetch('/api/management/subjects/list?page=1', {
+    const res = await fetch('/api/management/subjects?page=1', {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${managementToken}`
@@ -492,7 +492,7 @@ describe('List subjects that have given consent', () => {
     }
     //WHEN
     const managementToken = await managementJWT.sign({ id: 1 });
-    const res = await fetch('/api/management/subjects/list?page=2', {
+    const res = await fetch('/api/management/subjects?page=2', {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${managementToken}`
@@ -529,7 +529,7 @@ describe('Tests of listing rectification requests', () => {
     await createSubjectWithRectification();
 
     //WHEN
-    const res = await fetch('/api/management/subjects/rectification-requests/list', {
+    const res = await fetch('/api/management/subjects/rectification-requests', {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${managementToken}`
@@ -547,7 +547,7 @@ describe('Tests of listing rectification requests', () => {
     const managementToken = await managementJWT.sign({ id: 1 });
 
     //WHEN
-    const res = await fetch('/api/management/subjects/rectification-requests/list', {
+    const res = await fetch('/api/management/subjects/rectification-requests', {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${managementToken}`
@@ -565,7 +565,7 @@ describe('Tests of listing rectification requests', () => {
     //GIVEN
     const managementToken = await managementJWT.sign({ id: 1 });
     const subjectToken = await subjectJWT.sign({ subjectId: '646416818971' });
-    await fetch('/api/subject/give-consent', {
+    await fetch('/api/subject/consent', {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${subjectToken}`
@@ -578,7 +578,7 @@ describe('Tests of listing rectification requests', () => {
       }
     });
     for (let i = 0; i < 12; i++) {
-      await fetch('/api/subject/initiate-rectification', {
+      await fetch('/api/subject/rectification', {
         method: 'POST',
         headers: {
           Authorization: `Bearer ${subjectToken}`
@@ -593,7 +593,7 @@ describe('Tests of listing rectification requests', () => {
     }
 
     //WHEN
-    const res = await fetch('/api/management/subjects/rectification-requests/list?page=2', {
+    const res = await fetch('/api/management/subjects/rectification-requests?page=2', {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${managementToken}`
@@ -627,7 +627,7 @@ describe('Tests of listing rectification requests', () => {
     const managementToken = await managementJWT.sign({ id: 1 });
 
     //WHEN
-    const res = await fetch('/api/management/subjects/rectification-requests/list?page=6', {
+    const res = await fetch('/api/management/subjects/rectification-requests?page=6', {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${managementToken}`
@@ -647,7 +647,7 @@ describe('Tests of listing rectification requests', () => {
     const managementToken = await managementJWT.sign({ id: 1 });
 
     //WHEN
-    const res = await fetch('/api/management/subjects/rectification-requests/list', {
+    const res = await fetch('/api/management/subjects/rectification-requests', {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${managementToken}`
@@ -669,7 +669,7 @@ describe('Tests of listing rectification requests', () => {
       .delete();
 
     //WHEN
-    const res = await fetch('/api/management/subjects/rectification-requests/list', {
+    const res = await fetch('/api/management/subjects/rectification-requests', {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${managementToken}`
@@ -718,7 +718,7 @@ describe('Tests of listing archived rectification requests', () => {
     //GIVEN
     const managementToken = await managementJWT.sign({ id: 1 });
     const subjectToken = await subjectJWT.sign({ subjectId: '65498736186+968' });
-    await fetch('/api/subject/give-consent', {
+    await fetch('/api/subject/consent', {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${subjectToken}`
@@ -731,7 +731,7 @@ describe('Tests of listing archived rectification requests', () => {
       }
     });
     for (let i = 0; i < 12; i++) {
-      await fetch('/api/subject/initiate-rectification', {
+      await fetch('/api/subject/rectification', {
         method: 'POST',
         headers: {
           Authorization: `Bearer ${subjectToken}`
@@ -745,7 +745,7 @@ describe('Tests of listing archived rectification requests', () => {
       });
     }
 
-    let res1 = await fetch(`/api/management/subjects/rectification-requests/list`, {
+    let res1 = await fetch(`/api/management/subjects/rectification-requests`, {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${managementToken}`
@@ -754,8 +754,8 @@ describe('Tests of listing archived rectification requests', () => {
     const requestsData = await res1.json();
     const firstRequestId = requestsData.data[0].id;
     for (let i = firstRequestId; i < firstRequestId + 12; i++) {
-      await fetch(`/api/management/subjects/rectification-requests/${i}/update-status`, {
-        method: 'POST',
+      await fetch(`/api/management/subjects/rectification-requests/${i}`, {
+        method: 'PUT',
         headers: {
           Authorization: `Bearer ${managementToken}`
         },
@@ -968,9 +968,9 @@ describe('Update rectification request status', () => {
 
     //WHEN
     const res = await fetch(
-      `/api/management/subjects/rectification-requests/${rectificationRequestId}/update-status`,
+      `/api/management/subjects/rectification-requests/${rectificationRequestId}`,
       {
-        method: 'POST',
+        method: 'PUT',
         body: {
           status: RECTIFICATION_STATUSES.APPROVED
         },
@@ -995,9 +995,9 @@ describe('Update rectification request status', () => {
 
     //WHEN
     const res = await fetch(
-      `/api/management/subjects/rectification-requests/${rectificationRequestId}/update-status`,
+      `/api/management/subjects/rectification-requests/${rectificationRequestId}`,
       {
-        method: 'POST',
+        method: 'PUT',
         body: {
           status: RECTIFICATION_STATUSES.APPROVED
         },
@@ -1028,9 +1028,9 @@ describe('Update rectification request status', () => {
 
     //WHEN
     const res = await fetch(
-      `/api/management/subjects/rectification-requests/${rectificationRequestId}/update-status`,
+      `/api/management/subjects/rectification-requests/${rectificationRequestId}`,
       {
-        method: 'POST',
+        method: 'PUT',
         body: {
           status: RECTIFICATION_STATUSES.DISAPPROVED
         },
@@ -1053,9 +1053,9 @@ describe('Update rectification request status', () => {
 
     //WHEN
     const res = await fetch(
-      `/api/management/subjects/rectification-requests/${rectificationRequestId}/update-status`,
+      `/api/management/subjects/rectification-requests/${rectificationRequestId}`,
       {
-        method: 'POST',
+        method: 'PUT',
         headers: {
           Authorization: `Bearer ${managementToken}`
         },
@@ -1073,18 +1073,15 @@ describe('Update rectification request status', () => {
     const managementToken = await managementJWT.sign({ id: 1 });
 
     //WHEN
-    const res = await fetch(
-      `/api/management/subjects/rectification-requests/1212121/update-status`,
-      {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${managementToken}`
-        },
-        body: {
-          status: RECTIFICATION_STATUSES.APPROVED
-        }
+    const res = await fetch(`/api/management/subjects/rectification-requests/1212121`, {
+      method: 'PUT',
+      headers: {
+        Authorization: `Bearer ${managementToken}`
+      },
+      body: {
+        status: RECTIFICATION_STATUSES.APPROVED
       }
-    );
+    });
 
     //THEN
     expect(res.status).toEqual(404);
@@ -1103,9 +1100,9 @@ describe('Update rectification request status', () => {
 
     //WHEN
     const res = await fetch(
-      `/api/management/subjects/rectification-requests/${rectificationRequestId}/update-status`,
+      `/api/management/subjects/rectification-requests/${rectificationRequestId}`,
       {
-        method: 'POST',
+        method: 'PUT',
         body: {
           status: RECTIFICATION_STATUSES.APPROVED
         },

--- a/cg/test/management/users.api.spec.js
+++ b/cg/test/management/users.api.spec.js
@@ -16,7 +16,7 @@ afterAll(closeResources);
 describe('Management user Registration', () => {
   it('Should fail if no username/password is provided', async () => {
     // When
-    const res = await fetch('/api/management/users/register', {
+    const res = await fetch('/api/management/users', {
       method: 'POST',
       headers: { Authorization: `Bearer ${managementToken}` },
       body: {}
@@ -34,14 +34,14 @@ describe('Management user Registration', () => {
       username: 'manager',
       password: 'manager_password'
     };
-    const res1 = await fetch('/api/management/users/register', {
+    const res1 = await fetch('/api/management/users', {
       method: 'POST',
       headers: { Authorization: `Bearer ${managementToken}` },
       body: manager
     });
 
     // When
-    const res2 = await fetch('/api/management/users/register', {
+    const res2 = await fetch('/api/management/users', {
       method: 'POST',
       headers: { Authorization: `Bearer ${managementToken}` },
       body: {
@@ -60,7 +60,7 @@ describe('Management user Registration', () => {
 
   it('Should allow a manager to register', async () => {
     //When
-    const res = await fetch('/api/management/users/register', {
+    const res = await fetch('/api/management/users', {
       method: 'POST',
       headers: { Authorization: `Bearer ${managementToken}` },
       body: {
@@ -87,8 +87,8 @@ describe('Management user Registration', () => {
 describe('Management user removal', () => {
   it('Should not allow the removal of unregistered managers', async () => {
     //When
-    const res = await fetch('/api/management/users/999/remove', {
-      method: 'POST',
+    const res = await fetch('/api/management/users/999', {
+      method: 'DELETE',
       headers: {
         Authorization: `Bearer ${managementToken}`
       }
@@ -104,8 +104,8 @@ describe('Management user removal', () => {
 
   it('Should not allow the removal with an ID thats not a positive integer', async () => {
     //When
-    const res = await fetch('/api/management/users/string/remove', {
-      method: 'POST',
+    const res = await fetch('/api/management/users/string', {
+      method: 'DELETE',
       headers: {
         Authorization: `Bearer ${managementToken}`
       }
@@ -119,7 +119,7 @@ describe('Management user removal', () => {
 
   it('Should not allow the removal of the current user himself', async () => {
     //Given
-    const res1 = await fetch('/api/management/users/register', {
+    const res1 = await fetch('/api/management/users', {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${managementToken}`
@@ -142,11 +142,11 @@ describe('Management user removal', () => {
       }
     });
     const loggedUser = await res2.json();
-    const loggedUserToken = loggedUser.jwt; 
+    const loggedUserToken = loggedUser.jwt;
 
     //When
-    const res3 = await fetch(`/api/management/users/${registeredUserId}/remove`, {
-      method: 'POST',
+    const res3 = await fetch(`/api/management/users/${registeredUserId}`, {
+      method: 'DELETE',
       headers: {
         Authorization: `Bearer ${loggedUserToken}`
       }
@@ -162,7 +162,7 @@ describe('Management user removal', () => {
 
   it('Should allow the removal of a registered manager', async () => {
     //Given
-    await fetch('/api/management/users/register', {
+    await fetch('/api/management/users', {
       method: 'POST',
       headers: { Authorization: `Bearer ${managementToken}` },
       body: {
@@ -178,8 +178,8 @@ describe('Management user removal', () => {
     const [{ id }] = await res1.json();
 
     //When
-    const res2 = await fetch(`/api/management/users/${id}/remove`, {
-      method: 'POST',
+    const res2 = await fetch(`/api/management/users/${id}`, {
+      method: 'DELETE',
       headers: {
         Authorization: `Bearer ${managementToken}`
       }
@@ -213,7 +213,7 @@ describe('Management user Login', () => {
 
   it('Return unauthorized for wrong passwords', async () => {
     //Given
-    await fetch('/api/management/users/register', {
+    await fetch('/api/management/users', {
       method: 'POST',
       headers: { Authorization: `Bearer ${managementToken}` },
       body: {
@@ -256,7 +256,7 @@ describe('Management user Login', () => {
 
   it('Should allow a manager to login', async () => {
     //Given
-    await fetch('/api/management/users/register', {
+    await fetch('/api/management/users', {
       method: 'POST',
       headers: { Authorization: `Bearer ${managementToken}` },
       body: {
@@ -317,7 +317,7 @@ describe('Management user password update', () => {
 
   it('Should allow a managers password to be updated', async () => {
     //Given
-    await fetch('/api/management/users/register', {
+    await fetch('/api/management/users', {
       method: 'POST',
       headers: { Authorization: `Bearer ${managementToken}` },
       body: {
@@ -373,7 +373,7 @@ describe('Listing management users', () => {
 
   it('Should display correctly the registered managers', async () => {
     //Given
-    await fetch('/api/management/users/register', {
+    await fetch('/api/management/users', {
       method: 'POST',
       headers: { Authorization: `Bearer ${managementToken}` },
       body: {
@@ -381,7 +381,7 @@ describe('Listing management users', () => {
         password: 'manager1_password'
       }
     });
-    await fetch('/api/management/users/register', {
+    await fetch('/api/management/users', {
       method: 'POST',
       headers: { Authorization: `Bearer ${managementToken}` },
       body: {

--- a/cg/test/subjects/data-shares.api.spec.js
+++ b/cg/test/subjects/data-shares.api.spec.js
@@ -18,7 +18,7 @@ afterAll(closeResources);
 
 async function createUser(id, data = { name: 'test' }) {
   const token = await subjectJWT.sign({ subjectId: id });
-  await fetch('/api/subject/give-consent', {
+  await fetch('/api/subject/consent', {
     method: 'POST',
     body: {
       personalData: data,
@@ -41,7 +41,7 @@ describe('Listing data-shares', () => {
     await db('data_shares').insert({ subject_id: idHash, name: 'test2', token: 'token2' });
 
     //WHEN
-    const res = await fetchWithAuthorization('/api/subject/data-shares/list', token);
+    const res = await fetchWithAuthorization('/api/subject/data-shares', token);
 
     //THEN
     expect(res.status).toEqual(200);
@@ -65,7 +65,7 @@ describe('Listing data-shares', () => {
     const subjectId = '84291212';
     const token = await createUser(subjectId);
 
-    const res = await fetchWithAuthorization(`/api/subject/data-shares/list`, token);
+    const res = await fetchWithAuthorization(`/api/subject/data-shares`, token);
 
     expect(res.status).toEqual(200);
     expect(await res.json()).toHaveLength(0);
@@ -77,7 +77,7 @@ describe('Data share create', () => {
     const subjectId = '84215211';
     const token = await createUser(subjectId);
     const body = { name: 'test6' };
-    const res = await fetchWithAuthorization('/api/subject/data-shares/create', token, {
+    const res = await fetchWithAuthorization('/api/subject/data-shares', token, {
       method: 'POST',
       body
     });
@@ -91,7 +91,7 @@ describe('Data share create', () => {
   it('Should error if no name is provided', async () => {
     const subjectId = '8421511011';
     const token = await createUser(subjectId);
-    const res = await fetchWithAuthorization('/api/subject/data-shares/create', token, {
+    const res = await fetchWithAuthorization('/api/subject/data-shares', token, {
       method: 'POST',
       body: {}
     });
@@ -110,13 +110,9 @@ describe('Data share remove', () => {
 
     expect(dataShare).toBeTruthy();
 
-    const res = await fetchWithAuthorization(
-      `/api/subject/data-shares/${dataShare.id}/remove`,
-      token,
-      {
-        method: 'POST'
-      }
-    );
+    const res = await fetchWithAuthorization(`/api/subject/data-shares/${dataShare.id}`, token, {
+      method: 'DELETE'
+    });
 
     expect(res.status).toEqual(200);
     const [dataShare2] = await db('data_shares').where({ name: 'test7' });
@@ -139,7 +135,7 @@ describe('Data share sharing', () => {
   it('Should provide the users personal data in a json format if token is correct', async () => {
     const subjectId = '2';
     const token = await createUser(subjectId, { customData: true });
-    const res = await fetchWithAuthorization('/api/subject/data-shares/create', token, {
+    const res = await fetchWithAuthorization('/api/subject/data-shares', token, {
       method: 'POST',
       body: { name: 'testdatasharing' }
     });
@@ -167,7 +163,7 @@ describe('Data share sharing', () => {
     const idHash = hash(subjectId);
     const token = await createUser(subjectId);
 
-    const res = await fetchWithAuthorization('/api/subject/data-shares/create', token, {
+    const res = await fetchWithAuthorization('/api/subject/data-shares', token, {
       method: 'POST',
       body: { name: 'no-decryption-key' }
     });

--- a/cg/test/subjects/subjects.api.spec.js
+++ b/cg/test/subjects/subjects.api.spec.js
@@ -52,7 +52,7 @@ afterAll(closeResources);
 
 describe('Tests of subjects giving consent', () => {
   it('should return Unauthorized when no token is provided', async () => {
-    const res = await fetch('/api/subject/give-consent', {
+    const res = await fetch('/api/subject/consent', {
       method: 'POST',
       body: {}
     });
@@ -63,7 +63,7 @@ describe('Tests of subjects giving consent', () => {
 
   it('Should return Unauthorized when token has no subjectId', async () => {
     const token = await subjectJWT.sign({ test: '1' });
-    const res = await fetch('/api/subject/give-consent', {
+    const res = await fetch('/api/subject/consent', {
       method: 'POST',
       body: {},
       headers: {
@@ -83,7 +83,7 @@ describe('Tests of subjects giving consent', () => {
     const token = await subjectJWT.sign({ test: '10' }, { expiresIn: 1 });
     expect.assertions(2);
     setTimeout(async () => {
-      const res = await fetch('/api/subject/give-consent', {
+      const res = await fetch('/api/subject/consent', {
         method: 'POST',
         body: {},
         headers: {
@@ -99,7 +99,7 @@ describe('Tests of subjects giving consent', () => {
   it('Should return Unauthorized when not in controller mode', async () => {
     process.env.MODE = VALID_RUN_MODES.PROCESSOR;
     const token = await subjectJWT.sign({ subjectId: '1aa22b' });
-    const res = await fetch('/api/subject/give-consent', {
+    const res = await fetch('/api/subject/consent', {
       method: 'POST',
       body: {},
       headers: {
@@ -122,7 +122,7 @@ describe('Tests of subjects giving consent', () => {
     };
 
     // When
-    const res = await fetch('/api/subject/give-consent', {
+    const res = await fetch('/api/subject/consent', {
       method: 'POST',
       body: payload,
       headers: {
@@ -146,7 +146,7 @@ describe('Tests of subjects giving consent', () => {
     };
 
     // When
-    const res = await fetch('/api/subject/give-consent', {
+    const res = await fetch('/api/subject/consent', {
       method: 'POST',
       body: payload,
       headers: {
@@ -180,7 +180,7 @@ describe('Tests of subjects giving consent', () => {
     };
 
     // When
-    const res = await fetch('/api/subject/give-consent', {
+    const res = await fetch('/api/subject/consent', {
       method: 'POST',
       body: payload,
       headers: {
@@ -202,7 +202,7 @@ describe('Tests of subjects giving consent', () => {
     // Given
     const subjectToken = await subjectJWT.sign({ subjectId: '546857156' });
     const personalData = { sensitiveData: 'some sensitive data' };
-    await fetch('/api/subject/give-consent', {
+    await fetch('/api/subject/consent', {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${subjectToken}`
@@ -214,7 +214,7 @@ describe('Tests of subjects giving consent', () => {
     });
 
     // When
-    const res = await fetch('/api/subject/give-consent', {
+    const res = await fetch('/api/subject/consent', {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${subjectToken}`
@@ -243,7 +243,7 @@ describe('Tests of subjects giving consent', () => {
     };
 
     // When
-    const res = await fetch('/api/subject/give-consent', {
+    const res = await fetch('/api/subject/consent', {
       method: 'POST',
       body: payload,
       headers: {
@@ -297,7 +297,7 @@ describe('Tests of subjects giving consent', () => {
     };
 
     // When
-    const res = await fetch('/api/subject/give-consent', {
+    const res = await fetch('/api/subject/consent', {
       method: 'POST',
       body: payload,
       headers: {
@@ -319,7 +319,7 @@ describe('Tests of subjects updating their consented processors', () => {
   it('Should not allow a subject to update consent without specifying the processors consented', async () => {
     // Given
     const subjectToken = await subjectJWT.sign({ subjectId: '6496968798796713565' });
-    await fetch('/api/subject/give-consent', {
+    await fetch('/api/subject/consent', {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${subjectToken}`
@@ -331,8 +331,8 @@ describe('Tests of subjects updating their consented processors', () => {
     });
 
     // When
-    const res = await fetch('/api/subject/update-consent', {
-      method: 'POST',
+    const res = await fetch('/api/subject/consent', {
+      method: 'PUT',
       headers: {
         Authorization: `Bearer ${subjectToken}`
       },
@@ -348,7 +348,7 @@ describe('Tests of subjects updating their consented processors', () => {
   it('Should not allow an existing subject to update consent to a non-existent processor', async () => {
     // Given
     const subjectToken = await subjectJWT.sign({ subjectId: '54687316598649874' });
-    await fetch('/api/subject/give-consent', {
+    await fetch('/api/subject/consent', {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${subjectToken}`
@@ -362,8 +362,8 @@ describe('Tests of subjects updating their consented processors', () => {
     });
 
     // When
-    const res = await fetch('/api/subject/update-consent', {
-      method: 'POST',
+    const res = await fetch('/api/subject/consent', {
+      method: 'PUT',
       headers: {
         Authorization: `Bearer ${subjectToken}`
       },
@@ -387,7 +387,7 @@ describe('Tests of subjects updating their consented processors', () => {
       id: 89673521,
       name: 'No address processor'
     });
-    await fetch('/api/subject/give-consent', {
+    await fetch('/api/subject/consent', {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${subjectToken}`
@@ -401,8 +401,8 @@ describe('Tests of subjects updating their consented processors', () => {
     });
 
     // When
-    const res = await fetch('/api/subject/update-consent', {
-      method: 'POST',
+    const res = await fetch('/api/subject/consent', {
+      method: 'PUT',
       headers: {
         Authorization: `Bearer ${subjectToken}`
       },
@@ -424,8 +424,8 @@ describe('Tests of subjects updating their consented processors', () => {
     const subjectToken = await subjectJWT.sign({ subjectId: '1457636849461464612' });
 
     // When
-    const res = await fetch('/api/subject/update-consent', {
-      method: 'POST',
+    const res = await fetch('/api/subject/consent', {
+      method: 'PUT',
       headers: {
         Authorization: `Bearer ${subjectToken}`
       },
@@ -445,7 +445,7 @@ describe('Tests of subjects updating their consented processors', () => {
   it('Should allow an existing subject to update consent to the specified processors', async () => {
     // Given
     const subjectToken = await subjectJWT.sign({ subjectId: '168798764848474' });
-    await fetch('/api/subject/give-consent', {
+    await fetch('/api/subject/consent', {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${subjectToken}`
@@ -459,8 +459,8 @@ describe('Tests of subjects updating their consented processors', () => {
     });
 
     // When
-    const res = await fetch('/api/subject/update-consent', {
-      method: 'POST',
+    const res = await fetch('/api/subject/consent', {
+      method: 'PUT',
       headers: {
         Authorization: `Bearer ${subjectToken}`
       },
@@ -503,8 +503,8 @@ describe('Tests of subjects erasing data and revoking consent', () => {
     const subjectToken = await subjectJWT.sign({ subjectId: '8547567523' });
 
     // When
-    const res = await fetch('/api/subject/erase-data', {
-      method: 'POST',
+    const res = await fetch('/api/subject/data', {
+      method: 'DELETE',
       headers: {
         Authorization: `Bearer ${subjectToken}`
       }
@@ -525,7 +525,7 @@ describe('Tests of subjects erasing data and revoking consent', () => {
       name: 'subject',
       email: 'subject@clevertech.biz'
     };
-    const res1 = await fetch('/api/subject/give-consent', {
+    const res1 = await fetch('/api/subject/consent', {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${subjectToken}`
@@ -537,13 +537,13 @@ describe('Tests of subjects erasing data and revoking consent', () => {
     });
 
     // When
-    const res2 = await fetch('/api/subject/erase-data', {
-      method: 'POST',
+    const res2 = await fetch('/api/subject/data', {
+      method: 'DELETE',
       headers: {
         Authorization: `Bearer ${subjectToken}`
       }
     });
-    const res3 = await fetch('/api/subject/data-status', {
+    const res3 = await fetch('/api/subject/data/status', {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${subjectToken}`
@@ -590,7 +590,7 @@ describe('Tests of subjects getting their data status per processor', () => {
     const subjectToken = await subjectJWT.sign({ subjectId });
 
     // When
-    const res = await fetch('/api/subject/data-status', {
+    const res = await fetch('/api/subject/data/status', {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${subjectToken}`
@@ -628,7 +628,7 @@ describe('Tests of subjects accessing their data', () => {
       personalData,
       processors: []
     };
-    await fetch('/api/subject/give-consent', {
+    await fetch('/api/subject/consent', {
       method: 'POST',
       body: payload,
       headers: {
@@ -637,7 +637,7 @@ describe('Tests of subjects accessing their data', () => {
     });
 
     // When
-    const res = await fetch('/api/subject/access-data', {
+    const res = await fetch('/api/subject/data', {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${subjectToken}`
@@ -661,29 +661,29 @@ describe('Tests of subjects accessing their data', () => {
       personalData,
       processors: []
     };
-    await fetch('/api/subject/give-consent', {
+    await fetch('/api/subject/consent', {
       method: 'POST',
       body: payload,
       headers: {
         Authorization: `Bearer ${token}`
       }
     });
-    const res = await fetch('/api/subject/access-data', {
+    const res = await fetch('/api/subject/data', {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${token}`
       }
     });
     const data = await res.json();
-    const res2 = await fetch('/api/subject/erase-data', {
-      method: 'POST',
+    const res2 = await fetch('/api/subject/data', {
+      method: 'DELETE',
       headers: {
         Authorization: `Bearer ${token}`
       }
     });
 
     // When
-    const res3 = await fetch('/api/subject/access-data', {
+    const res3 = await fetch('/api/subject/data', {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${token}`
@@ -707,7 +707,7 @@ describe('Tests of subjects initiating rectifications', () => {
       personalData: {},
       processors: []
     };
-    await fetch('/api/subject/give-consent', {
+    await fetch('/api/subject/consent', {
       method: 'POST',
       body: payload,
       headers: {
@@ -716,7 +716,7 @@ describe('Tests of subjects initiating rectifications', () => {
     });
 
     // When
-    const res = await fetch('/api/subject/initiate-rectification', {
+    const res = await fetch('/api/subject/rectification', {
       method: 'POST',
       body: { rectificationPayload: { name: 'dave' }, requestReason: 'my name is dave' },
       headers: {
@@ -740,7 +740,7 @@ describe('Tests of subjects initiating rectifications', () => {
       personalData: {},
       processors: []
     };
-    await fetch('/api/subject/give-consent', {
+    await fetch('/api/subject/consent', {
       method: 'POST',
       body: payload,
       headers: {
@@ -749,7 +749,7 @@ describe('Tests of subjects initiating rectifications', () => {
     });
 
     // When
-    const res = await fetch('/api/subject/initiate-rectification', {
+    const res = await fetch('/api/subject/rectification', {
       method: 'POST',
       body: { rectificationPayload: { name: 'dave' }, requestReason: 'my name is dave' },
       headers: {
@@ -776,7 +776,7 @@ describe('Tests of subjects initiating rectifications', () => {
       personalData: {},
       processors: []
     };
-    await fetch('/api/subject/give-consent', {
+    await fetch('/api/subject/consent', {
       method: 'POST',
       body: payload,
       headers: {
@@ -785,7 +785,7 @@ describe('Tests of subjects initiating rectifications', () => {
     });
 
     // When
-    const res = await fetch('/api/subject/initiate-rectification', {
+    const res = await fetch('/api/subject/rectification', {
       method: 'POST',
       body: {},
       headers: {
@@ -807,7 +807,7 @@ describe('Tests of subjects initiating rectifications', () => {
       personalData: {},
       processors: []
     };
-    await fetch('/api/subject/give-consent', {
+    await fetch('/api/subject/consent', {
       method: 'POST',
       body: payload,
       headers: {
@@ -819,7 +819,7 @@ describe('Tests of subjects initiating rectifications', () => {
       .delete();
 
     // When
-    const res = await fetch('/api/subject/initiate-rectification', {
+    const res = await fetch('/api/subject/rectification', {
       method: 'POST',
       body: { rectificationPayload: { name: 'dave' }, requestReason: 'my name is dave' },
       headers: {
@@ -839,7 +839,7 @@ describe('Tests of subjects restricting the processing of their data', () => {
   it('Should not allow a subject that has given consent to restrict without specifying the actions to restrict', async () => {
     // Given
     const subjectToken = await subjectJWT.sign({ subjectId: '6947987194298749879' });
-    await fetch('/api/subject/give-consent', {
+    await fetch('/api/subject/consent', {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${subjectToken}`
@@ -853,7 +853,7 @@ describe('Tests of subjects restricting the processing of their data', () => {
     });
 
     // When
-    const res = await fetch('/api/subject/restrict', {
+    const res = await fetch('/api/subject/restrictions', {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${subjectToken}`
@@ -872,7 +872,7 @@ describe('Tests of subjects restricting the processing of their data', () => {
     const subjectToken = await subjectJWT.sign({ subjectId: '98489719179871' });
 
     // When
-    const res = await fetch('/api/subject/restrict', {
+    const res = await fetch('/api/subject/restrictions', {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${subjectToken}`
@@ -895,7 +895,7 @@ describe('Tests of subjects restricting the processing of their data', () => {
   it('Should allow a subject that has given consent to restrict the processing of his data', async () => {
     // Given
     const subjectToken = await subjectJWT.sign({ subjectId: '124589635745498' });
-    await fetch('/api/subject/give-consent', {
+    await fetch('/api/subject/consent', {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${subjectToken}`
@@ -909,7 +909,7 @@ describe('Tests of subjects restricting the processing of their data', () => {
     });
 
     // When
-    const res = await fetch('/api/subject/restrict', {
+    const res = await fetch('/api/subject/restrictions', {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${subjectToken}`
@@ -936,7 +936,7 @@ describe('Tests of subjects getting their restrictons', () => {
     const subjectToken = await subjectJWT.sign({ subjectId: '989874937987987' });
 
     // When
-    const res = await fetch('/api/subject/get-restrictions', {
+    const res = await fetch('/api/subject/restrictions', {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${subjectToken}`
@@ -954,7 +954,7 @@ describe('Tests of subjects getting their restrictons', () => {
   it('Should allow a subject that has given consent to get his restrictions', async () => {
     // Given
     const subjectToken = await subjectJWT.sign({ subjectId: '989874937987987' });
-    await fetch('/api/subject/give-consent', {
+    await fetch('/api/subject/consent', {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${subjectToken}`
@@ -968,7 +968,7 @@ describe('Tests of subjects getting their restrictons', () => {
     });
 
     // When
-    const res = await fetch('/api/subject/get-restrictions', {
+    const res = await fetch('/api/subject/restrictions', {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${subjectToken}`
@@ -990,7 +990,7 @@ describe('Tests of subjects objecting to the processing of their data', () => {
   it('Should not allow a subject that has given consent to object without specifying the objection', async () => {
     // Given
     const subjectToken = await subjectJWT.sign({ subjectId: '641698719871987' });
-    await fetch('/api/subject/give-consent', {
+    await fetch('/api/subject/consent', {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${subjectToken}`
@@ -1044,7 +1044,7 @@ describe('Tests of subjects objecting to the processing of their data', () => {
   it('Should allow a subject that has given consent to object to the processing of his data', async () => {
     // Given
     const subjectToken = await subjectJWT.sign({ subjectId: '68149879879817982' });
-    await fetch('/api/subject/give-consent', {
+    await fetch('/api/subject/consent', {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${subjectToken}`
@@ -1083,7 +1083,7 @@ describe('Tests of subjects getting their objection status', () => {
     const subjectToken = await subjectJWT.sign({ subjectId: '124785212598348' });
 
     // When
-    const res = await fetch('/api/subject/get-objection', {
+    const res = await fetch('/api/subject/objection', {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${subjectToken}`
@@ -1101,7 +1101,7 @@ describe('Tests of subjects getting their objection status', () => {
   it('Should allow a subject that has given consent to get his objection status', async () => {
     // Given
     const subjectToken = await subjectJWT.sign({ subjectId: '6546873212765469874' });
-    await fetch('/api/subject/give-consent', {
+    await fetch('/api/subject/consent', {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${subjectToken}`
@@ -1115,7 +1115,7 @@ describe('Tests of subjects getting their objection status', () => {
     });
 
     // When
-    const res = await fetch('/api/subject/get-objection', {
+    const res = await fetch('/api/subject/objection', {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${subjectToken}`

--- a/frontend/src/js-sdk/modules/subject.js
+++ b/frontend/src/js-sdk/modules/subject.js
@@ -5,16 +5,16 @@ export const SUBJECT = 'subject';
 export default class Subject extends ResourceBase {
   giveConsent(payload) {
     const method = 'POST';
-    return this.request(`${SUBJECT}/give-consent`, { method, payload });
+    return this.request(`${SUBJECT}/consent`, { method, payload });
   }
 
   updateConsent(payload) {
-    const method = 'POST';
-    return this.request(`${SUBJECT}/update-consent`, { method, payload });
+    const method = 'PUT';
+    return this.request(`${SUBJECT}/consent`, { method, payload });
   }
 
   getObjectionStatus() {
-    return this.request(`${SUBJECT}/get-objection`);
+    return this.request(`${SUBJECT}/objection`);
   }
 
   updateObjection(restrictProcessing) {
@@ -26,16 +26,16 @@ export default class Subject extends ResourceBase {
   }
 
   accessData() {
-    return this.request(`${SUBJECT}/access-data`);
+    return this.request(`${SUBJECT}/data`);
   }
 
   eraseData() {
-    const method = 'POST';
-    return this.request(`${SUBJECT}/erase-data`, { method });
+    const method = 'DELETE';
+    return this.request(`${SUBJECT}/data`, { method });
   }
 
   getDataStatus() {
-    return this.request(`${SUBJECT}/data-status`);
+    return this.request(`${SUBJECT}/data/status`);
   }
 
   getProcessors() {
@@ -47,34 +47,34 @@ export default class Subject extends ResourceBase {
   }
 
   getDataShares() {
-    return this.request(`${SUBJECT}/data-shares/list`);
+    return this.request(`${SUBJECT}/data-shares`);
   }
 
   addDataShare(payload) {
     const method = 'POST';
-    return this.request(`${SUBJECT}/data-shares/create`, { method, payload });
+    return this.request(`${SUBJECT}/data-shares`, { method, payload });
   }
 
   removeDataShare(dataShareId) {
-    const method = 'POST';
-    return this.request(`${SUBJECT}/data-shares/${dataShareId}/remove`, { method });
+    const method = 'DELETE';
+    return this.request(`${SUBJECT}/data-shares/${dataShareId}`, { method });
   }
 
   initiateRectification(requestReason, rectificationPayload) {
     const method = 'POST';
-    return this.request(`${SUBJECT}/initiate-rectification`, {
+    return this.request(`${SUBJECT}/rectification`, {
       method,
       payload: { requestReason, rectificationPayload }
     });
   }
 
   getRestrictions() {
-    return this.request(`${SUBJECT}/get-restrictions`);
+    return this.request(`${SUBJECT}/restrictions`);
   }
 
   updateRestrictions({ directMarketing, emailCommunication, research }) {
     const method = 'POST';
-    return this.request(`${SUBJECT}/restrict`, {
+    return this.request(`${SUBJECT}/restrictions`, {
       method,
       payload: {
         directMarketing,


### PR DESCRIPTION
use HTTP methods for CRUD operations - API management endpoints
use HTTP methods for CRUD operations - API subject endpoints
use HTTP methods for CRUD operations - API processor endpoints
