### PR TITLE
Fix processors without blockchain address issues in the demo

### DIFF
--- a/cg/src/domains/management/processors/processors.controller.js
+++ b/cg/src/domains/management/processors/processors.controller.js
@@ -24,7 +24,7 @@ class ProcessorsController {
     res.send({ success: true });
   }
 
-  // TEST FUNCTIONS USED ONLY FOR DEVELOPMENT
+  // TEST FUNCTIONS USED FOR DEMOS AND DEVELOPMENT
 
   async testAddProcessor(req, res) {
     await this.processorsService.testAddProcessor(req.body);

--- a/cg/src/domains/management/processors/processors.validators.js
+++ b/cg/src/domains/management/processors/processors.validators.js
@@ -40,8 +40,8 @@ const testAddProcessorValidator = celebrate({
       .max(255),
     logoUrl: Joi.string().max(255),
     description: Joi.string(),
-    scopes: Joi.array().items(Joi.string()),
-    accountAddress: Joi.string().regex(/^0x[\da-fA-F]{40}$/) // Blockchain account address
+    scopes: Joi.array().items(Joi.string())
+    //accountAddress: Joi.string().regex(/^0x[\da-fA-F]{40}$/) // Blockchain account address
   })
 });
 

--- a/cg/test/management/processors.api.spec.js
+++ b/cg/test/management/processors.api.spec.js
@@ -466,8 +466,7 @@ describe('TEST - Add processor used for development', () => {
       name: 'Processor 123ABC unique name',
       logoUrl: 'https://upload.wikimedia.org/wikipedia/commons/5/52/Free_logo.svg',
       description: `some description`,
-      scopes: ['email', 'first name'],
-      accountAddress: '0x00000000000000000000000000000000000000A5'
+      scopes: ['email', 'first name']
     };
 
     // When
@@ -495,8 +494,7 @@ describe('TEST - Add processor used for development', () => {
     );
     const [processorAddress] = await db('processor_address').where({ processor_id: processor.id });
     expect(processorAddress).toBeDefined();
-    expect(processorAddress.address).toEqual(payload.accountAddress);
-    expect(await isProcessor('0x00000000000000000000000000000000000000A5')).toBeTruthy();
+    expect(await isProcessor(processorAddress.address)).toBeTruthy();
   });
 });
 


### PR DESCRIPTION
When trying to add a new processor without a blockchain address, it would add, but it would make future sign ins to error out due to the missing blockchain address.
Also, when trying to remove a processor that had consent from at least 1 subject, it would not remove the processor. 
Both these bugs are fixed in this PR