### PR TITLE
ci: test Node.js 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 sudo: required
 language: node_js
 node_js:
+  - 'node'
+  - '10'
   - '8'
 cache: 
   yarn: true


### PR DESCRIPTION
<!-- START doctoc generated TOC please keep comment here to allow auto update -->
<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*

- [Proposed Changes](#proposed-changes)

<!-- END doctoc generated TOC please keep comment here to allow auto update -->

Fixes #

## Proposed Changes

Test Node.js 8, 10 (LTS) and current stable (11).
